### PR TITLE
feat: Draft/Undraft Colonists (#22)

### DIFF
--- a/Source/RimMind/Tools/ColonistTools.cs
+++ b/Source/RimMind/Tools/ColonistTools.cs
@@ -164,6 +164,97 @@ namespace RimMind.Tools
             return obj.ToString();
         }
 
+        public static string DraftColonist(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return ToolExecutor.JsonError("Name parameter required.");
+
+            var pawn = FindPawnByName(name);
+            if (pawn == null) return ToolExecutor.JsonError("Colonist '" + name + "' not found.");
+
+            if (pawn.drafter == null) return ToolExecutor.JsonError("Colonist cannot be drafted.");
+            if (pawn.Downed) return ToolExecutor.JsonError("Colonist is downed and cannot be drafted.");
+
+            pawn.drafter.Drafted = true;
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["colonist"] = pawn.Name?.ToStringShort ?? "Unknown";
+            result["status"] = "drafted";
+            return result.ToString();
+        }
+
+        public static string UndraftColonist(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return ToolExecutor.JsonError("Name parameter required.");
+
+            var pawn = FindPawnByName(name);
+            if (pawn == null) return ToolExecutor.JsonError("Colonist '" + name + "' not found.");
+
+            if (pawn.drafter == null) return ToolExecutor.JsonError("Colonist cannot be drafted.");
+
+            pawn.drafter.Drafted = false;
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["colonist"] = pawn.Name?.ToStringShort ?? "Unknown";
+            result["status"] = "undrafted";
+            return result.ToString();
+        }
+
+        public static string DraftAll()
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            var colonists = map.mapPawns.FreeColonists;
+            int drafted = 0;
+            int failed = 0;
+
+            foreach (var pawn in colonists)
+            {
+                if (pawn.drafter != null && !pawn.Downed)
+                {
+                    pawn.drafter.Drafted = true;
+                    drafted++;
+                }
+                else
+                {
+                    failed++;
+                }
+            }
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["drafted"] = drafted;
+            result["failed"] = failed;
+            result["total"] = colonists.Count();
+            return result.ToString();
+        }
+
+        public static string UndraftAll()
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            var colonists = map.mapPawns.FreeColonists;
+            int undrafted = 0;
+
+            foreach (var pawn in colonists)
+            {
+                if (pawn.drafter != null)
+                {
+                    pawn.drafter.Drafted = false;
+                    undrafted++;
+                }
+            }
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["undrafted"] = undrafted;
+            result["total"] = colonists.Count();
+            return result.ToString();
+        }
+
         public static Pawn FindPawnByName(string name)
         {
             var map = Find.CurrentMap;

--- a/Source/RimMind/Tools/ToolDefinitions.cs
+++ b/Source/RimMind/Tools/ToolDefinitions.cs
@@ -15,6 +15,12 @@ namespace RimMind.Tools
                 MakeParam("name", "string", "The colonist's name (first name or nickname)")));
             tools.Add(MakeTool("get_colonist_health", "Get health details for a specific colonist: injuries, diseases, immunity progress, bionics/implants, pain level, and consciousness.",
                 MakeParam("name", "string", "The colonist's name")));
+            tools.Add(MakeTool("draft_colonist", "Draft a colonist for combat. Drafted colonists will follow orders instead of performing normal work tasks.",
+                MakeParam("name", "string", "The colonist's name")));
+            tools.Add(MakeTool("undraft_colonist", "Undraft a colonist, returning them to normal work tasks.",
+                MakeParam("name", "string", "The colonist's name")));
+            tools.Add(MakeTool("draft_all", "Draft all colonists for combat at once."));
+            tools.Add(MakeTool("undraft_all", "Undraft all colonists, returning them to normal work."));
 
             // Social Tools
             tools.Add(MakeTool("get_relationships", "Get a colonist's social relationships: opinions of and from other colonists, relationship types (lover, spouse, rival, friend, etc).",

--- a/Source/RimMind/Tools/ToolExecutor.cs
+++ b/Source/RimMind/Tools/ToolExecutor.cs
@@ -13,6 +13,10 @@ namespace RimMind.Tools
             { "list_colonists", args => ColonistTools.ListColonists() },
             { "get_colonist_details", args => ColonistTools.GetColonistDetails(args?["name"]?.Value) },
             { "get_colonist_health", args => ColonistTools.GetColonistHealth(args?["name"]?.Value) },
+            { "draft_colonist", args => ColonistTools.DraftColonist(args?["name"]?.Value) },
+            { "undraft_colonist", args => ColonistTools.UndraftColonist(args?["name"]?.Value) },
+            { "draft_all", args => ColonistTools.DraftAll() },
+            { "undraft_all", args => ColonistTools.UndraftAll() },
 
             // Social
             { "get_relationships", args => SocialTools.GetRelationships(args?["name"]?.Value) },


### PR DESCRIPTION
## Description
Implements draft/undraft functionality for colonists as requested in #22.

## Changes
- Added `draft_colonist(name)` - Draft a colonist for combat
- Added `undraft_colonist(name)` - Return colonist to normal work  
- Added `draft_all()` - Draft all colonists at once
- Added `undraft_all()` - Undraft all colonists

## Implementation
- Uses `Pawn.drafter.Drafted` API
- Handles error cases (downed pawns, invalid names, null drafter)
- Returns success status and colonist names
- Registered in ToolDefinitions and ToolExecutor

## Testing
- Code follows established patterns from existing tools
- Error handling for edge cases (downed, missing drafter)
- Batch operations count successes/failures

## Value
AI can now respond to threats by drafting defenders automatically.

Closes #22