### PR TITLE
feat: Set Colonist Schedules (#24)

### DIFF
--- a/Source/RimMind/Tools/ToolDefinitions.cs
+++ b/Source/RimMind/Tools/ToolDefinitions.cs
@@ -26,6 +26,13 @@ namespace RimMind.Tools
             tools.Add(MakeTool("get_bills", "Get active production bills at workbenches: recipe name, target count, ingredients needed, assigned worker, and whether suspended.",
                 MakeOptionalParam("workbench", "string", "Filter by workbench name. If omitted, returns bills from all workbenches.")));
             tools.Add(MakeTool("get_schedules", "Get daily schedules for all colonists: hour-by-hour assignments (Sleep, Work, Anything, Joy/Recreation)."));
+            tools.Add(MakeTool("set_schedule", "Set the schedule assignment for a specific colonist at a specific hour. Assignments: 'Work', 'Sleep', 'Anything', 'Joy'.",
+                MakeParam("colonist", "string", "The colonist's name"),
+                MakeParam("hour", "integer", "Hour of day (0-23)"),
+                MakeParam("assignment", "string", "Activity assignment ('Work', 'Sleep', 'Anything', or 'Joy')")));
+            tools.Add(MakeTool("copy_schedule", "Copy one colonist's schedule to another colonist.",
+                MakeParam("from", "string", "Source colonist name"),
+                MakeParam("to", "string", "Target colonist name")));
 
             // Colony Tools
             tools.Add(MakeTool("get_colony_overview", "Get a high-level colony overview: colonist count, total wealth, days survived, difficulty setting, storyteller, and map tile info."));

--- a/Source/RimMind/Tools/ToolExecutor.cs
+++ b/Source/RimMind/Tools/ToolExecutor.cs
@@ -22,6 +22,8 @@ namespace RimMind.Tools
             { "get_work_priorities", args => WorkTools.GetWorkPriorities() },
             { "get_bills", args => WorkTools.GetBills(args?["workbench"]?.Value) },
             { "get_schedules", args => WorkTools.GetSchedules() },
+            { "set_schedule", args => WorkTools.SetSchedule(args?["colonist"]?.Value, args?["hour"]?.AsInt ?? 0, args?["assignment"]?.Value) },
+            { "copy_schedule", args => WorkTools.CopySchedule(args?["from"]?.Value, args?["to"]?.Value) },
 
             // Colony
             { "get_colony_overview", args => ColonyTools.GetColonyOverview() },

--- a/Source/RimMind/Tools/WorkTools.cs
+++ b/Source/RimMind/Tools/WorkTools.cs
@@ -107,5 +107,74 @@ namespace RimMind.Tools
             result["schedules"] = arr;
             return result.ToString();
         }
+
+        public static string SetSchedule(string colonistName, int hour, string assignment)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            if (string.IsNullOrEmpty(colonistName)) return ToolExecutor.JsonError("colonist parameter required.");
+            if (hour < 0 || hour > 23) return ToolExecutor.JsonError("hour must be 0-23.");
+            if (string.IsNullOrEmpty(assignment)) return ToolExecutor.JsonError("assignment parameter required.");
+
+            var pawn = ColonistTools.FindPawnByName(colonistName);
+            if (pawn == null) return ToolExecutor.JsonError("Colonist '" + colonistName + "' not found.");
+
+            if (pawn.timetable == null) return ToolExecutor.JsonError("Colonist has no schedule.");
+
+            // Find assignment by matching defName or label
+            string assignmentLower = assignment.ToLower();
+            var assignmentDef = DefDatabase<TimeAssignmentDef>.AllDefsListForReading
+                .FirstOrDefault(a => 
+                    a.defName.ToLower() == assignmentLower ||
+                    (a.label?.ToLower() == assignmentLower) ||
+                    (a.labelShort?.ToLower() == assignmentLower));
+
+            if (assignmentDef == null)
+            {
+                return ToolExecutor.JsonError("Assignment '" + assignment + "' not found. Available: " +
+                    string.Join(", ", DefDatabase<TimeAssignmentDef>.AllDefsListForReading.Select(a => a.label ?? a.defName)));
+            }
+
+            pawn.timetable.SetAssignment(hour, assignmentDef);
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["colonist"] = pawn.Name?.ToStringShort ?? "Unknown";
+            result["hour"] = hour;
+            result["assignment"] = assignmentDef.label ?? assignmentDef.defName;
+            return result.ToString();
+        }
+
+        public static string CopySchedule(string fromName, string toName)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            if (string.IsNullOrEmpty(fromName)) return ToolExecutor.JsonError("from parameter required.");
+            if (string.IsNullOrEmpty(toName)) return ToolExecutor.JsonError("to parameter required.");
+
+            var fromPawn = ColonistTools.FindPawnByName(fromName);
+            if (fromPawn == null) return ToolExecutor.JsonError("Source colonist '" + fromName + "' not found.");
+
+            var toPawn = ColonistTools.FindPawnByName(toName);
+            if (toPawn == null) return ToolExecutor.JsonError("Target colonist '" + toName + "' not found.");
+
+            if (fromPawn.timetable == null) return ToolExecutor.JsonError("Source colonist has no schedule.");
+            if (toPawn.timetable == null) return ToolExecutor.JsonError("Target colonist has no schedule.");
+
+            for (int hour = 0; hour < 24; hour++)
+            {
+                var assignment = fromPawn.timetable.GetAssignment(hour);
+                toPawn.timetable.SetAssignment(hour, assignment);
+            }
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["from"] = fromPawn.Name?.ToStringShort ?? "Unknown";
+            result["to"] = toPawn.Name?.ToStringShort ?? "Unknown";
+            result["message"] = "Schedule copied successfully";
+            return result.ToString();
+        }
     }
 }


### PR DESCRIPTION
## Description
Implements colonist schedule management as requested in #24.

## Changes
- Added `set_schedule(colonist, hour, assignment)` tool
- Added `copy_schedule(from, to)` tool

## Implementation
- Uses `Pawn.timetable.SetAssignment(hour, TimeAssignmentDef)` API
- Fuzzy matching for assignment names (Sleep, Work, Anything, Joy)
- Validates hour range (0-23)
- Copy entire 24-hour schedules between colonists

## Value
AI can now manage sleep schedules, create night shifts, and optimize recreation time.

Closes #24