### PR TITLE
feat: Prioritize Jobs (Right-click Actions) (#25)

### DIFF
--- a/Source/RimMind/Tools/JobTools.cs
+++ b/Source/RimMind/Tools/JobTools.cs
@@ -1,0 +1,187 @@
+using System.Linq;
+using RimMind.API;
+using RimWorld;
+using Verse;
+using Verse.AI;
+
+namespace RimMind.Tools
+{
+    public static class JobTools
+    {
+        public static string PrioritizeRescue(string colonistName, string targetName)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            if (string.IsNullOrEmpty(colonistName)) return ToolExecutor.JsonError("colonist parameter required.");
+            if (string.IsNullOrEmpty(targetName)) return ToolExecutor.JsonError("target parameter required.");
+
+            var colonist = ColonistTools.FindPawnByName(colonistName);
+            if (colonist == null) return ToolExecutor.JsonError("Colonist '" + colonistName + "' not found.");
+
+            var target = FindPawnByNameInMap(targetName, map);
+            if (target == null) return ToolExecutor.JsonError("Target pawn '" + targetName + "' not found.");
+
+            if (!target.Downed) return ToolExecutor.JsonError("Target is not downed.");
+
+            var job = JobMaker.MakeJob(JobDefOf.Rescue, target, target.CurrentBed());
+            if (colonist.jobs.TryTakeOrderedJob(job, JobTag.Misc))
+            {
+                var result = new JSONObject();
+                result["success"] = true;
+                result["colonist"] = colonist.Name?.ToStringShort ?? "Unknown";
+                result["target"] = target.Name?.ToStringShort ?? "Unknown";
+                result["action"] = "rescue";
+                return result.ToString();
+            }
+
+            return ToolExecutor.JsonError("Failed to assign rescue job.");
+        }
+
+        public static string PrioritizeTend(string doctorName, string patientName)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            if (string.IsNullOrEmpty(doctorName)) return ToolExecutor.JsonError("doctor parameter required.");
+            if (string.IsNullOrEmpty(patientName)) return ToolExecutor.JsonError("patient parameter required.");
+
+            var doctor = ColonistTools.FindPawnByName(doctorName);
+            if (doctor == null) return ToolExecutor.JsonError("Doctor '" + doctorName + "' not found.");
+
+            var patient = FindPawnByNameInMap(patientName, map);
+            if (patient == null) return ToolExecutor.JsonError("Patient '" + patientName + "' not found.");
+
+            if (!patient.health.HasHediffsNeedingTend()) 
+                return ToolExecutor.JsonError("Patient does not need tending.");
+
+            var job = JobMaker.MakeJob(JobDefOf.TendPatient, patient);
+            if (doctor.jobs.TryTakeOrderedJob(job, JobTag.Misc))
+            {
+                var result = new JSONObject();
+                result["success"] = true;
+                result["doctor"] = doctor.Name?.ToStringShort ?? "Unknown";
+                result["patient"] = patient.Name?.ToStringShort ?? "Unknown";
+                result["action"] = "tend";
+                return result.ToString();
+            }
+
+            return ToolExecutor.JsonError("Failed to assign tend job.");
+        }
+
+        public static string PrioritizeHaul(string colonistName, int x, int z)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            if (string.IsNullOrEmpty(colonistName)) return ToolExecutor.JsonError("colonist parameter required.");
+
+            var colonist = ColonistTools.FindPawnByName(colonistName);
+            if (colonist == null) return ToolExecutor.JsonError("Colonist '" + colonistName + "' not found.");
+
+            var cell = new IntVec3(x, 0, z);
+            if (!cell.InBounds(map)) return ToolExecutor.JsonError("Coordinates out of bounds.");
+
+            var things = cell.GetThingList(map);
+            var haulable = things.FirstOrDefault(t => t.def.EverHaulable && !t.IsForbidden(Faction.OfPlayer));
+
+            if (haulable == null) return ToolExecutor.JsonError("No haulable item found at " + x + "," + z);
+
+            var job = HaulAIUtility.HaulToStorageJob(colonist, haulable);
+            if (job != null && colonist.jobs.TryTakeOrderedJob(job, JobTag.Misc))
+            {
+                var result = new JSONObject();
+                result["success"] = true;
+                result["colonist"] = colonist.Name?.ToStringShort ?? "Unknown";
+                result["item"] = haulable.LabelCap.ToString();
+                result["action"] = "haul";
+                return result.ToString();
+            }
+
+            return ToolExecutor.JsonError("Failed to assign haul job.");
+        }
+
+        public static string PrioritizeRepair(string colonistName, int x, int z)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            if (string.IsNullOrEmpty(colonistName)) return ToolExecutor.JsonError("colonist parameter required.");
+
+            var colonist = ColonistTools.FindPawnByName(colonistName);
+            if (colonist == null) return ToolExecutor.JsonError("Colonist '" + colonistName + "' not found.");
+
+            var cell = new IntVec3(x, 0, z);
+            if (!cell.InBounds(map)) return ToolExecutor.JsonError("Coordinates out of bounds.");
+
+            var building = cell.GetEdifice(map);
+            if (building == null) return ToolExecutor.JsonError("No building found at " + x + "," + z);
+
+            if (building.HitPoints >= building.MaxHitPoints)
+                return ToolExecutor.JsonError("Building is not damaged.");
+
+            var job = JobMaker.MakeJob(JobDefOf.Repair, building);
+            if (colonist.jobs.TryTakeOrderedJob(job, JobTag.Misc))
+            {
+                var result = new JSONObject();
+                result["success"] = true;
+                result["colonist"] = colonist.Name?.ToStringShort ?? "Unknown";
+                result["building"] = building.LabelCap.ToString();
+                result["action"] = "repair";
+                return result.ToString();
+            }
+
+            return ToolExecutor.JsonError("Failed to assign repair job.");
+        }
+
+        public static string PrioritizeClean(string colonistName, int x, int z, int radius)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            if (string.IsNullOrEmpty(colonistName)) return ToolExecutor.JsonError("colonist parameter required.");
+            if (radius < 1 || radius > 20) return ToolExecutor.JsonError("radius must be 1-20.");
+
+            var colonist = ColonistTools.FindPawnByName(colonistName);
+            if (colonist == null) return ToolExecutor.JsonError("Colonist '" + colonistName + "' not found.");
+
+            var center = new IntVec3(x, 0, z);
+            if (!center.InBounds(map)) return ToolExecutor.JsonError("Coordinates out of bounds.");
+
+            // Find filth in area
+            var filthList = map.listerFilthInHomeArea.FilthInHomeArea
+                .Where(f => f.Position.InHorDistOf(center, radius))
+                .OrderBy(f => f.Position.DistanceTo(center))
+                .ToList();
+
+            if (!filthList.Any())
+                return ToolExecutor.JsonError("No filth found within radius " + radius + " of " + x + "," + z);
+
+            var nearestFilth = filthList.First();
+            var job = JobMaker.MakeJob(JobDefOf.Clean, nearestFilth);
+            if (colonist.jobs.TryTakeOrderedJob(job, JobTag.Misc))
+            {
+                var result = new JSONObject();
+                result["success"] = true;
+                result["colonist"] = colonist.Name?.ToStringShort ?? "Unknown";
+                result["filth"] = nearestFilth.LabelCap.ToString();
+                result["location"] = nearestFilth.Position.x + "," + nearestFilth.Position.z;
+                result["action"] = "clean";
+                result["filthInArea"] = filthList.Count;
+                return result.ToString();
+            }
+
+            return ToolExecutor.JsonError("Failed to assign clean job.");
+        }
+
+        private static Pawn FindPawnByNameInMap(string name, Map map)
+        {
+            string lower = name.ToLower();
+            return map.mapPawns.AllPawns
+                .FirstOrDefault(p =>
+                    p.Name?.ToStringShort?.ToLower() == lower ||
+                    p.Name?.ToStringFull?.ToLower().Contains(lower) == true ||
+                    p.LabelShort?.ToLower() == lower);
+        }
+    }
+}

--- a/Source/RimMind/Tools/ToolDefinitions.cs
+++ b/Source/RimMind/Tools/ToolDefinitions.cs
@@ -27,6 +27,27 @@ namespace RimMind.Tools
                 MakeOptionalParam("workbench", "string", "Filter by workbench name. If omitted, returns bills from all workbenches.")));
             tools.Add(MakeTool("get_schedules", "Get daily schedules for all colonists: hour-by-hour assignments (Sleep, Work, Anything, Joy/Recreation)."));
 
+            // Job Prioritization Tools
+            tools.Add(MakeTool("prioritize_rescue", "Force a colonist to immediately rescue a downed pawn.",
+                MakeParam("colonist", "string", "The rescuer's name"),
+                MakeParam("target", "string", "The downed pawn's name")));
+            tools.Add(MakeTool("prioritize_tend", "Force a doctor to immediately tend to a patient.",
+                MakeParam("doctor", "string", "The doctor's name"),
+                MakeParam("patient", "string", "The patient's name")));
+            tools.Add(MakeTool("prioritize_haul", "Force a colonist to haul a specific item at the given coordinates.",
+                MakeParam("colonist", "string", "The colonist's name"),
+                MakeParam("x", "integer", "X coordinate of the item"),
+                MakeParam("z", "integer", "Z coordinate of the item")));
+            tools.Add(MakeTool("prioritize_repair", "Force a colonist to repair a damaged building at the given coordinates.",
+                MakeParam("colonist", "string", "The colonist's name"),
+                MakeParam("x", "integer", "X coordinate of the building"),
+                MakeParam("z", "integer", "Z coordinate of the building")));
+            tools.Add(MakeTool("prioritize_clean", "Force a colonist to clean filth in an area.",
+                MakeParam("colonist", "string", "The colonist's name"),
+                MakeParam("x", "integer", "X coordinate of the center"),
+                MakeParam("z", "integer", "Z coordinate of the center"),
+                MakeParam("radius", "integer", "Radius to search for filth (1-20)")));
+
             // Colony Tools
             tools.Add(MakeTool("get_colony_overview", "Get a high-level colony overview: colonist count, total wealth, days survived, difficulty setting, storyteller, and map tile info."));
             tools.Add(MakeTool("get_resources", "Get resource counts in the colony's stockpiles.",

--- a/Source/RimMind/Tools/ToolExecutor.cs
+++ b/Source/RimMind/Tools/ToolExecutor.cs
@@ -23,6 +23,13 @@ namespace RimMind.Tools
             { "get_bills", args => WorkTools.GetBills(args?["workbench"]?.Value) },
             { "get_schedules", args => WorkTools.GetSchedules() },
 
+            // Job Prioritization
+            { "prioritize_rescue", args => JobTools.PrioritizeRescue(args?["colonist"]?.Value, args?["target"]?.Value) },
+            { "prioritize_tend", args => JobTools.PrioritizeTend(args?["doctor"]?.Value, args?["patient"]?.Value) },
+            { "prioritize_haul", args => JobTools.PrioritizeHaul(args?["colonist"]?.Value, args?["x"]?.AsInt ?? 0, args?["z"]?.AsInt ?? 0) },
+            { "prioritize_repair", args => JobTools.PrioritizeRepair(args?["colonist"]?.Value, args?["x"]?.AsInt ?? 0, args?["z"]?.AsInt ?? 0) },
+            { "prioritize_clean", args => JobTools.PrioritizeClean(args?["colonist"]?.Value, args?["x"]?.AsInt ?? 0, args?["z"]?.AsInt ?? 0, args?["radius"]?.AsInt ?? 5) },
+
             // Colony
             { "get_colony_overview", args => ColonyTools.GetColonyOverview() },
             { "get_resources", args => ColonyTools.GetResources(args?["category"]?.Value) },


### PR DESCRIPTION
## Description
Implements job prioritization tools as requested in #25.

## Changes
- Added `prioritize_rescue(colonist, target)` - Force rescue downed pawn
- Added `prioritize_tend(doctor, patient)` - Immediate medical care
- Added `prioritize_haul(colonist, x, z)` - Haul specific item
- Added `prioritize_repair(colonist, x, z)` - Repair damaged building
- Added `prioritize_clean(colonist, x, z, radius)` - Clean area

## Implementation
- Created new JobTools.cs file
- Uses `Pawn.jobs.TryTakeOrderedJob(job, JobTag.Misc)` API
- Validates targets (downed status, damage, filth presence)
- Returns detailed success/failure information

## Value
AI can now handle emergencies automatically - rescue downed colonists, prioritize medical care, force critical hauling.

Closes #25