### PR TITLE
feat: Create/Modify Production Bills (#26)

### DIFF
--- a/Source/RimMind/Tools/ToolDefinitions.cs
+++ b/Source/RimMind/Tools/ToolDefinitions.cs
@@ -25,6 +25,21 @@ namespace RimMind.Tools
             tools.Add(MakeTool("get_work_priorities", "Get the work priority grid for all colonists: each work type (Doctor, Cook, Hunt, Construct, Grow, Mine, Research, etc.) and its priority level (1=highest, 4=lowest, 0=disabled)."));
             tools.Add(MakeTool("get_bills", "Get active production bills at workbenches: recipe name, target count, ingredients needed, assigned worker, and whether suspended.",
                 MakeOptionalParam("workbench", "string", "Filter by workbench name. If omitted, returns bills from all workbenches.")));
+            tools.Add(MakeTool("list_recipes", "List all available recipes at a specific workbench with ingredients and products.",
+                MakeParam("workbench", "string", "Workbench name (e.g., 'stove', 'smithy', 'tailor')")));
+            tools.Add(MakeTool("create_bill", "Create a new production bill at a workbench.",
+                MakeParam("workbench", "string", "Workbench name"),
+                MakeParam("recipe", "string", "Recipe name"),
+                MakeParam("count", "integer", "Number of items to produce")));
+            tools.Add(MakeTool("suspend_bill", "Suspend a production bill (pause it).",
+                MakeParam("workbench", "string", "Workbench name"),
+                MakeParam("billIndex", "integer", "Bill index (0-based, use get_bills to see indices)")));
+            tools.Add(MakeTool("resume_bill", "Resume a suspended production bill.",
+                MakeParam("workbench", "string", "Workbench name"),
+                MakeParam("billIndex", "integer", "Bill index (0-based)")));
+            tools.Add(MakeTool("delete_bill", "Delete a production bill.",
+                MakeParam("workbench", "string", "Workbench name"),
+                MakeParam("billIndex", "integer", "Bill index (0-based)")));
             tools.Add(MakeTool("get_schedules", "Get daily schedules for all colonists: hour-by-hour assignments (Sleep, Work, Anything, Joy/Recreation)."));
 
             // Colony Tools

--- a/Source/RimMind/Tools/ToolExecutor.cs
+++ b/Source/RimMind/Tools/ToolExecutor.cs
@@ -21,6 +21,11 @@ namespace RimMind.Tools
             // Work
             { "get_work_priorities", args => WorkTools.GetWorkPriorities() },
             { "get_bills", args => WorkTools.GetBills(args?["workbench"]?.Value) },
+            { "list_recipes", args => WorkTools.ListRecipes(args?["workbench"]?.Value) },
+            { "create_bill", args => WorkTools.CreateBill(args?["workbench"]?.Value, args?["recipe"]?.Value, args?["count"]?.AsInt ?? 1) },
+            { "suspend_bill", args => WorkTools.SuspendBill(args?["workbench"]?.Value, args?["billIndex"]?.AsInt ?? 0) },
+            { "resume_bill", args => WorkTools.ResumeBill(args?["workbench"]?.Value, args?["billIndex"]?.AsInt ?? 0) },
+            { "delete_bill", args => WorkTools.DeleteBill(args?["workbench"]?.Value, args?["billIndex"]?.AsInt ?? 0) },
             { "get_schedules", args => WorkTools.GetSchedules() },
 
             // Colony

--- a/Source/RimMind/Tools/WorkTools.cs
+++ b/Source/RimMind/Tools/WorkTools.cs
@@ -53,9 +53,11 @@ namespace RimMind.Tools
                 if (workTable == null) continue;
                 if (filterLower != null && !workTable.LabelCap.ToString().ToLower().Contains(filterLower)) continue;
 
+                int index = 0;
                 foreach (var bill in workTable.BillStack.Bills)
                 {
                     var obj = new JSONObject();
+                    obj["billIndex"] = index++;
                     obj["workbench"] = workTable.LabelCap.ToString();
                     obj["recipe"] = bill.recipe?.LabelCap.ToString() ?? "Unknown";
                     obj["suspended"] = bill.suspended;
@@ -105,6 +107,171 @@ namespace RimMind.Tools
 
             var result = new JSONObject();
             result["schedules"] = arr;
+            return result.ToString();
+        }
+
+        public static string ListRecipes(string workbenchName)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            if (string.IsNullOrEmpty(workbenchName)) return ToolExecutor.JsonError("workbench parameter required.");
+
+            string benchLower = workbenchName.ToLower();
+            var workbench = map.listerBuildings.allBuildingsColonist
+                .OfType<Building_WorkTable>()
+                .FirstOrDefault(b => b.LabelCap.ToString().ToLower().Contains(benchLower));
+
+            if (workbench == null)
+                return ToolExecutor.JsonError("Workbench '" + workbenchName + "' not found.");
+
+            var recipes = workbench.def.AllRecipes ?? new System.Collections.Generic.List<RecipeDef>();
+            var arr = new JSONArray();
+
+            foreach (var recipe in recipes.Where(r => r.AvailableNow))
+            {
+                var obj = new JSONObject();
+                obj["name"] = recipe.LabelCap.ToString();
+                obj["defName"] = recipe.defName;
+                obj["description"] = recipe.description ?? "";
+                
+                if (recipe.products != null && recipe.products.Any())
+                {
+                    var products = new JSONArray();
+                    foreach (var prod in recipe.products)
+                        products.Add(prod.thingDef.LabelCap.ToString() + " x" + prod.count);
+                    obj["products"] = products;
+                }
+
+                if (recipe.ingredients != null && recipe.ingredients.Any())
+                {
+                    var ingredients = new JSONArray();
+                    foreach (var ing in recipe.ingredients)
+                        ingredients.Add(ing.Summary);
+                    obj["ingredients"] = ingredients;
+                }
+
+                arr.Add(obj);
+            }
+
+            var result = new JSONObject();
+            result["workbench"] = workbench.LabelCap.ToString();
+            result["recipes"] = arr;
+            result["count"] = arr.Count;
+            return result.ToString();
+        }
+
+        public static string CreateBill(string workbenchName, string recipeName, int count)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            if (string.IsNullOrEmpty(workbenchName)) return ToolExecutor.JsonError("workbench parameter required.");
+            if (string.IsNullOrEmpty(recipeName)) return ToolExecutor.JsonError("recipe parameter required.");
+            if (count < 1) return ToolExecutor.JsonError("count must be at least 1.");
+
+            string benchLower = workbenchName.ToLower();
+            var workbench = map.listerBuildings.allBuildingsColonist
+                .OfType<Building_WorkTable>()
+                .FirstOrDefault(b => b.LabelCap.ToString().ToLower().Contains(benchLower));
+
+            if (workbench == null)
+                return ToolExecutor.JsonError("Workbench '" + workbenchName + "' not found.");
+
+            string recipeLower = recipeName.ToLower();
+            var recipe = (workbench.def.AllRecipes ?? new System.Collections.Generic.List<RecipeDef>())
+                .FirstOrDefault(r => 
+                    r.LabelCap.ToString().ToLower().Contains(recipeLower) ||
+                    r.defName.ToLower() == recipeLower);
+
+            if (recipe == null)
+                return ToolExecutor.JsonError("Recipe '" + recipeName + "' not found for this workbench.");
+
+            var bill = recipe.MakeNewBill();
+            if (bill is Bill_Production prodBill)
+            {
+                prodBill.repeatMode = BillRepeatModeDefOf.RepeatCount;
+                prodBill.repeatCount = count;
+            }
+
+            workbench.BillStack.AddBill(bill);
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["workbench"] = workbench.LabelCap.ToString();
+            result["recipe"] = recipe.LabelCap.ToString();
+            result["count"] = count;
+            result["billIndex"] = workbench.BillStack.Bills.Count - 1;
+            return result.ToString();
+        }
+
+        public static string SuspendBill(string workbenchName, int billIndex)
+        {
+            return SetBillSuspended(workbenchName, billIndex, true);
+        }
+
+        public static string ResumeBill(string workbenchName, int billIndex)
+        {
+            return SetBillSuspended(workbenchName, billIndex, false);
+        }
+
+        public static string DeleteBill(string workbenchName, int billIndex)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            if (string.IsNullOrEmpty(workbenchName)) return ToolExecutor.JsonError("workbench parameter required.");
+
+            string benchLower = workbenchName.ToLower();
+            var workbench = map.listerBuildings.allBuildingsColonist
+                .OfType<Building_WorkTable>()
+                .FirstOrDefault(b => b.LabelCap.ToString().ToLower().Contains(benchLower));
+
+            if (workbench == null)
+                return ToolExecutor.JsonError("Workbench '" + workbenchName + "' not found.");
+
+            if (billIndex < 0 || billIndex >= workbench.BillStack.Bills.Count)
+                return ToolExecutor.JsonError("Bill index out of range (0-" + (workbench.BillStack.Bills.Count - 1) + ").");
+
+            var bill = workbench.BillStack.Bills[billIndex];
+            string recipeName = bill.recipe?.LabelCap.ToString() ?? "Unknown";
+
+            workbench.BillStack.Delete(bill);
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["workbench"] = workbench.LabelCap.ToString();
+            result["deletedRecipe"] = recipeName;
+            result["remainingBills"] = workbench.BillStack.Bills.Count;
+            return result.ToString();
+        }
+
+        private static string SetBillSuspended(string workbenchName, int billIndex, bool suspended)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            if (string.IsNullOrEmpty(workbenchName)) return ToolExecutor.JsonError("workbench parameter required.");
+
+            string benchLower = workbenchName.ToLower();
+            var workbench = map.listerBuildings.allBuildingsColonist
+                .OfType<Building_WorkTable>()
+                .FirstOrDefault(b => b.LabelCap.ToString().ToLower().Contains(benchLower));
+
+            if (workbench == null)
+                return ToolExecutor.JsonError("Workbench '" + workbenchName + "' not found.");
+
+            if (billIndex < 0 || billIndex >= workbench.BillStack.Bills.Count)
+                return ToolExecutor.JsonError("Bill index out of range (0-" + (workbench.BillStack.Bills.Count - 1) + ").");
+
+            var bill = workbench.BillStack.Bills[billIndex];
+            bill.suspended = suspended;
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["workbench"] = workbench.LabelCap.ToString();
+            result["recipe"] = bill.recipe?.LabelCap.ToString() ?? "Unknown";
+            result["suspended"] = suspended;
             return result.ToString();
         }
     }


### PR DESCRIPTION
## Description
Implements production bill management as requested in #26.

## Changes
- Added `list_recipes(workbench)` - List all available recipes
- Added `create_bill(workbench, recipe, count)` - Create production bill
- Added `suspend_bill(workbench, billIndex)` - Pause bill
- Added `resume_bill(workbench, billIndex)` - Resume bill
- Added `delete_bill(workbench, billIndex)` - Remove bill
- Enhanced `get_bills` to include billIndex for referencing

## Implementation
- Uses `BillStack.AddBill()`, `BillStack.Delete()` APIs
- Fuzzy matching for workbench and recipe names
- Sets repeat count and mode for production bills
- Returns detailed information about created/modified bills

## Value
AI can now manage colony production - 'make 20 meals', 'craft medicine when low', adjust production dynamically.

Closes #26