### PR TITLE
feat: Set Growing Zone Crops (#28)

### DIFF
--- a/Source/RimMind/Tools/ToolDefinitions.cs
+++ b/Source/RimMind/Tools/ToolDefinitions.cs
@@ -105,6 +105,10 @@ namespace RimMind.Tools
             tools.Add(MakeTool("delete_zone", "Delete a zone by its label. Works on both real RimWorld zones (stockpile, growing) and custom planning zones. For native zones, frees the cells. Use list_zones to find zone names.",
                 MakeParam("label", "string", "The label/name of the zone to delete"),
                 MakeOptionalParam("remove_plans", "boolean", "Also remove plan designations in the area (planning zones only, default: false)")));
+            tools.Add(MakeTool("set_crop", "Change which crop is planted in a growing zone.",
+                MakeParam("zoneName", "string", "Growing zone name"),
+                MakeParam("plantType", "string", "Crop to plant (e.g., 'rice', 'corn', 'potatoes', 'healroot', 'cotton')")));
+            tools.Add(MakeTool("get_recommended_crops", "Get a list of recommended crops based on current season, growth time, yield, and purpose. Shows which crops can grow now and their characteristics."));
 
             // Building Tools
             tools.Add(MakeTool("list_buildable", "List available buildings that can be constructed. Shows defName, label, size, material requirements, and research status. Use 'category' to filter (Structure, Furniture, Production, Power, Security, Temperature, Misc, Joy). Without filter, shows all buildings grouped by category.",

--- a/Source/RimMind/Tools/ToolExecutor.cs
+++ b/Source/RimMind/Tools/ToolExecutor.cs
@@ -66,6 +66,8 @@ namespace RimMind.Tools
             { "list_zones", args => ZoneTools.ListZones() },
             { "create_zone", args => ZoneTools.CreateZone(args) },
             { "delete_zone", args => ZoneTools.DeleteZone(args) },
+            { "set_crop", args => ZoneTools.SetCrop(args?["zoneName"]?.Value, args?["plantType"]?.Value) },
+            { "get_recommended_crops", args => ZoneTools.GetRecommendedCrops() },
 
             // Building
             { "list_buildable", args => BuildingTools.ListBuildable(args) },


### PR DESCRIPTION
## Description
Implements growing zone crop management as requested in #28.

## Changes
- Added `set_crop(zoneName, plantType)` - Change planted crop
- Added `get_recommended_crops()` - Season-based crop recommendations

## Implementation
- Uses `Zone_Growing.SetPlantDefToGrow(PlantDef)` API
- Fuzzy matching for zone names and crop types
- Recommendations show: growth time, yield, fertility requirements, season suitability
- Categorizes by purpose: Food, Medicine, Beauty, Resource
- Filters out winter-unsuitable crops during winter

## Value
AI can now manage farming intelligently - 'plant rice before winter', 'switch to healroot', optimize crop selection.

Closes #28