### PR TITLE
feat: Assign Allowed Areas (#29)

### DIFF
--- a/Source/RimMind/Tools/AreaTools.cs
+++ b/Source/RimMind/Tools/AreaTools.cs
@@ -1,0 +1,146 @@
+using System.Linq;
+using RimMind.API;
+using RimWorld;
+using Verse;
+
+namespace RimMind.Tools
+{
+    public static class AreaTools
+    {
+        public static string RestrictToArea(string colonistName, string areaName)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            if (string.IsNullOrEmpty(colonistName)) return ToolExecutor.JsonError("colonist parameter required.");
+            if (string.IsNullOrEmpty(areaName)) return ToolExecutor.JsonError("areaName parameter required.");
+
+            var pawn = ColonistTools.FindPawnByName(colonistName);
+            if (pawn == null) return ToolExecutor.JsonError("Colonist '" + colonistName + "' not found.");
+
+            if (pawn.playerSettings == null)
+                return ToolExecutor.JsonError("Colonist has no player settings.");
+
+            // Find area
+            string areaLower = areaName.ToLower();
+            var area = map.areaManager.AllAreas
+                .Where(a => a.AssignableAsAllowed())
+                .FirstOrDefault(a => a.Label.ToLower().Contains(areaLower));
+
+            if (area == null)
+            {
+                var availableAreas = map.areaManager.AllAreas
+                    .Where(a => a.AssignableAsAllowed())
+                    .Select(a => a.Label)
+                    .Take(10);
+                return ToolExecutor.JsonError("Area '" + areaName + "' not found. Available: " + string.Join(", ", availableAreas));
+            }
+
+            pawn.playerSettings.AreaRestrictionInPawnCurrentMap = area;
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["colonist"] = pawn.Name?.ToStringShort ?? "Unknown";
+            result["area"] = area.Label;
+            result["cellCount"] = area.TrueCount;
+            return result.ToString();
+        }
+
+        public static string Unrestrict(string colonistName)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            if (string.IsNullOrEmpty(colonistName)) return ToolExecutor.JsonError("colonist parameter required.");
+
+            var pawn = ColonistTools.FindPawnByName(colonistName);
+            if (pawn == null) return ToolExecutor.JsonError("Colonist '" + colonistName + "' not found.");
+
+            if (pawn.playerSettings == null)
+                return ToolExecutor.JsonError("Colonist has no player settings.");
+
+            pawn.playerSettings.AreaRestrictionInPawnCurrentMap = null;
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["colonist"] = pawn.Name?.ToStringShort ?? "Unknown";
+            result["restriction"] = "removed";
+            return result.ToString();
+        }
+
+        public static string GetAreaRestrictions()
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            var arr = new JSONArray();
+
+            foreach (var pawn in map.mapPawns.FreeColonists)
+            {
+                if (pawn.playerSettings == null) continue;
+
+                var obj = new JSONObject();
+                obj["colonist"] = pawn.Name?.ToStringShort ?? "Unknown";
+                
+                var restriction = pawn.playerSettings.AreaRestrictionInPawnCurrentMap;
+                if (restriction != null)
+                {
+                    obj["area"] = restriction.Label;
+                    obj["restricted"] = true;
+                }
+                else
+                {
+                    obj["restricted"] = false;
+                }
+
+                arr.Add(obj);
+            }
+
+            var result = new JSONObject();
+            result["restrictions"] = arr;
+            result["count"] = arr.Count;
+            return result.ToString();
+        }
+
+        public static string ListAreas()
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            var arr = new JSONArray();
+
+            foreach (var area in map.areaManager.AllAreas.Where(a => a.AssignableAsAllowed()))
+            {
+                var obj = new JSONObject();
+                obj["label"] = area.Label;
+                obj["cellCount"] = area.TrueCount;
+                obj["type"] = area.GetType().Name.Replace("Area_", "");
+
+                // Get bounds
+                if (area.TrueCount > 0)
+                {
+                    int minX = int.MaxValue, minZ = int.MaxValue;
+                    int maxX = int.MinValue, maxZ = int.MinValue;
+                    foreach (var cell in area.ActiveCells)
+                    {
+                        if (cell.x < minX) minX = cell.x;
+                        if (cell.x > maxX) maxX = cell.x;
+                        if (cell.z < minZ) minZ = cell.z;
+                        if (cell.z > maxZ) maxZ = cell.z;
+                    }
+                    obj["x1"] = minX;
+                    obj["z1"] = minZ;
+                    obj["x2"] = maxX;
+                    obj["z2"] = maxZ;
+                }
+
+                arr.Add(obj);
+            }
+
+            var result = new JSONObject();
+            result["areas"] = arr;
+            result["count"] = arr.Count;
+            return result.ToString();
+        }
+    }
+}

--- a/Source/RimMind/Tools/ToolDefinitions.cs
+++ b/Source/RimMind/Tools/ToolDefinitions.cs
@@ -106,6 +106,15 @@ namespace RimMind.Tools
                 MakeParam("label", "string", "The label/name of the zone to delete"),
                 MakeOptionalParam("remove_plans", "boolean", "Also remove plan designations in the area (planning zones only, default: false)")));
 
+            // Area Restriction Tools
+            tools.Add(MakeTool("list_areas", "List all allowed areas that can be assigned to colonists."));
+            tools.Add(MakeTool("get_area_restrictions", "Get current area restrictions for all colonists."));
+            tools.Add(MakeTool("restrict_to_area", "Restrict a colonist to a specific allowed area (e.g., Home area, custom areas).",
+                MakeParam("colonist", "string", "The colonist's name"),
+                MakeParam("areaName", "string", "Area name to restrict to")));
+            tools.Add(MakeTool("unrestrict", "Remove area restriction from a colonist, allowing them to go anywhere.",
+                MakeParam("colonist", "string", "The colonist's name")));
+
             // Building Tools
             tools.Add(MakeTool("list_buildable", "List available buildings that can be constructed. Shows defName, label, size, material requirements, and research status. Use 'category' to filter (Structure, Furniture, Production, Power, Security, Temperature, Misc, Joy). Without filter, shows all buildings grouped by category.",
                 MakeOptionalParam("category", "string", "Filter by building category (e.g., 'Structure', 'Furniture', 'Production', 'Power', 'Security')")));

--- a/Source/RimMind/Tools/ToolExecutor.cs
+++ b/Source/RimMind/Tools/ToolExecutor.cs
@@ -67,6 +67,12 @@ namespace RimMind.Tools
             { "create_zone", args => ZoneTools.CreateZone(args) },
             { "delete_zone", args => ZoneTools.DeleteZone(args) },
 
+            // Area Restrictions
+            { "list_areas", args => AreaTools.ListAreas() },
+            { "get_area_restrictions", args => AreaTools.GetAreaRestrictions() },
+            { "restrict_to_area", args => AreaTools.RestrictToArea(args?["colonist"]?.Value, args?["areaName"]?.Value) },
+            { "unrestrict", args => AreaTools.Unrestrict(args?["colonist"]?.Value) },
+
             // Building
             { "list_buildable", args => BuildingTools.ListBuildable(args) },
             { "get_building_info", args => BuildingTools.GetBuildingInfo(args) },


### PR DESCRIPTION
## Description
Implements area restriction management as requested in #29.

## Changes
- Added `list_areas()` - List all available allowed areas
- Added `get_area_restrictions()` - View current restrictions
- Added `restrict_to_area(colonist, areaName)` - Restrict movement
- Added `unrestrict(colonist)` - Remove restriction

## Implementation
- Created new AreaTools.cs file
- Uses `Pawn.playerSettings.AreaRestrictionInPawnCurrentMap` API
- Fuzzy matching for area names
- Shows cell counts and bounds for areas

## Value
Keep colonists safe - 'stay inside during raid', 'don't go near danger zones'.

Closes #29