### PR TITLE
feat: Assign Beds & Ownership (#30)

### DIFF
--- a/Source/RimMind/Tools/BedTools.cs
+++ b/Source/RimMind/Tools/BedTools.cs
@@ -1,0 +1,188 @@
+using System.Linq;
+using RimMind.API;
+using RimWorld;
+using Verse;
+
+namespace RimMind.Tools
+{
+    public static class BedTools
+    {
+        public static string ListBeds()
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            var arr = new JSONArray();
+
+            foreach (var bed in map.listerBuildings.AllBuildingsColonistOfClass<Building_Bed>())
+            {
+                var obj = new JSONObject();
+                obj["label"] = bed.LabelCap.ToString();
+                obj["x"] = bed.Position.x;
+                obj["z"] = bed.Position.z;
+                obj["forPrisoners"] = bed.ForPrisoners;
+                obj["medical"] = bed.Medical;
+
+                if (bed.def.building != null)
+                {
+                    obj["sleepingSlotsCount"] = bed.def.building.bed_maxBodySize > 1.0f ? 2 : 1;
+                }
+
+                var owners = bed.OwnersForReading;
+                if (owners != null && owners.Count > 0)
+                {
+                    var ownerNames = new JSONArray();
+                    foreach (var owner in owners)
+                        ownerNames.Add(owner.Name?.ToStringShort ?? "Unknown");
+                    obj["owners"] = ownerNames;
+                    obj["assigned"] = true;
+                }
+                else
+                {
+                    obj["assigned"] = false;
+                }
+
+                // Room quality
+                var room = bed.GetRoom();
+                if (room != null && !room.PsychologicallyOutdoors)
+                {
+                    obj["impressiveness"] = room.GetStat(RoomStatDefOf.Impressiveness).ToString("F0");
+                }
+
+                arr.Add(obj);
+            }
+
+            var result = new JSONObject();
+            result["beds"] = arr;
+            result["totalBeds"] = arr.Count;
+            return result.ToString();
+        }
+
+        public static string AssignBed(string colonistName, int x, int z)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            if (string.IsNullOrEmpty(colonistName)) return ToolExecutor.JsonError("colonist parameter required.");
+
+            var pawn = ColonistTools.FindPawnByName(colonistName);
+            if (pawn == null) return ToolExecutor.JsonError("Colonist '" + colonistName + "' not found.");
+
+            var cell = new IntVec3(x, 0, z);
+            if (!cell.InBounds(map)) return ToolExecutor.JsonError("Coordinates out of bounds.");
+
+            var bed = cell.GetThingList(map).OfType<Building_Bed>().FirstOrDefault();
+            if (bed == null) return ToolExecutor.JsonError("No bed found at " + x + "," + z);
+
+            if (bed.ForPrisoners)
+                return ToolExecutor.JsonError("Cannot assign colonist to prisoner bed.");
+
+            if (bed.Medical)
+                return ToolExecutor.JsonError("Cannot assign ownership of medical bed.");
+
+            // Check if bed is full
+            var currentOwners = bed.OwnersForReading;
+            int maxOwners = bed.def.building.bed_maxBodySize > 1.0f ? 2 : 1;
+            
+            if (currentOwners != null && currentOwners.Count >= maxOwners && !currentOwners.Contains(pawn))
+                return ToolExecutor.JsonError("Bed is full (max " + maxOwners + " owners).");
+
+            // Unassign from current bed
+            if (pawn.ownership != null && pawn.ownership.OwnedBed != null)
+                pawn.ownership.UnclaimBed();
+
+            // Assign new bed
+            bed.TryAssignPawn(pawn);
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["colonist"] = pawn.Name?.ToStringShort ?? "Unknown";
+            result["bed"] = bed.LabelCap.ToString();
+            result["location"] = x + "," + z;
+
+            var newOwners = bed.OwnersForReading;
+            if (newOwners != null && newOwners.Count > 0)
+            {
+                var ownerNames = new JSONArray();
+                foreach (var owner in newOwners)
+                    ownerNames.Add(owner.Name?.ToStringShort ?? "Unknown");
+                result["allOwners"] = ownerNames;
+            }
+
+            return result.ToString();
+        }
+
+        public static string UnassignBed(string colonistName)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            if (string.IsNullOrEmpty(colonistName)) return ToolExecutor.JsonError("colonist parameter required.");
+
+            var pawn = ColonistTools.FindPawnByName(colonistName);
+            if (pawn == null) return ToolExecutor.JsonError("Colonist '" + colonistName + "' not found.");
+
+            if (pawn.ownership == null || pawn.ownership.OwnedBed == null)
+                return ToolExecutor.JsonError("Colonist does not own a bed.");
+
+            var bed = pawn.ownership.OwnedBed;
+            string bedLabel = bed.LabelCap.ToString();
+
+            pawn.ownership.UnclaimBed();
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["colonist"] = pawn.Name?.ToStringShort ?? "Unknown";
+            result["previousBed"] = bedLabel;
+            return result.ToString();
+        }
+
+        public static string GetBedAssignments()
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            var arr = new JSONArray();
+
+            foreach (var pawn in map.mapPawns.FreeColonists)
+            {
+                var obj = new JSONObject();
+                obj["colonist"] = pawn.Name?.ToStringShort ?? "Unknown";
+
+                if (pawn.ownership != null && pawn.ownership.OwnedBed != null)
+                {
+                    var bed = pawn.ownership.OwnedBed;
+                    obj["bed"] = bed.LabelCap.ToString();
+                    obj["x"] = bed.Position.x;
+                    obj["z"] = bed.Position.z;
+                    obj["assigned"] = true;
+
+                    // Check if sharing
+                    var owners = bed.OwnersForReading;
+                    if (owners != null && owners.Count > 1)
+                    {
+                        var sharing = new JSONArray();
+                        foreach (var owner in owners)
+                        {
+                            if (owner != pawn)
+                                sharing.Add(owner.Name?.ToStringShort ?? "Unknown");
+                        }
+                        if (sharing.Count > 0)
+                            obj["sharingWith"] = sharing;
+                    }
+                }
+                else
+                {
+                    obj["assigned"] = false;
+                }
+
+                arr.Add(obj);
+            }
+
+            var result = new JSONObject();
+            result["assignments"] = arr;
+            result["count"] = arr.Count;
+            return result.ToString();
+        }
+    }
+}

--- a/Source/RimMind/Tools/ToolDefinitions.cs
+++ b/Source/RimMind/Tools/ToolDefinitions.cs
@@ -106,6 +106,16 @@ namespace RimMind.Tools
                 MakeParam("label", "string", "The label/name of the zone to delete"),
                 MakeOptionalParam("remove_plans", "boolean", "Also remove plan designations in the area (planning zones only, default: false)")));
 
+            // Bed Assignment Tools
+            tools.Add(MakeTool("list_beds", "List all beds in the colony with owner assignments, locations, and room quality."));
+            tools.Add(MakeTool("get_bed_assignments", "Get current bed assignments for all colonists."));
+            tools.Add(MakeTool("assign_bed", "Assign a colonist to a specific bed. Use list_beds to find bed locations.",
+                MakeParam("colonist", "string", "The colonist's name"),
+                MakeParam("x", "integer", "Bed X coordinate"),
+                MakeParam("z", "integer", "Bed Z coordinate")));
+            tools.Add(MakeTool("unassign_bed", "Remove a colonist's bed assignment.",
+                MakeParam("colonist", "string", "The colonist's name")));
+
             // Building Tools
             tools.Add(MakeTool("list_buildable", "List available buildings that can be constructed. Shows defName, label, size, material requirements, and research status. Use 'category' to filter (Structure, Furniture, Production, Power, Security, Temperature, Misc, Joy). Without filter, shows all buildings grouped by category.",
                 MakeOptionalParam("category", "string", "Filter by building category (e.g., 'Structure', 'Furniture', 'Production', 'Power', 'Security')")));

--- a/Source/RimMind/Tools/ToolExecutor.cs
+++ b/Source/RimMind/Tools/ToolExecutor.cs
@@ -67,6 +67,12 @@ namespace RimMind.Tools
             { "create_zone", args => ZoneTools.CreateZone(args) },
             { "delete_zone", args => ZoneTools.DeleteZone(args) },
 
+            // Bed Assignments
+            { "list_beds", args => BedTools.ListBeds() },
+            { "get_bed_assignments", args => BedTools.GetBedAssignments() },
+            { "assign_bed", args => BedTools.AssignBed(args?["colonist"]?.Value, args?["x"]?.AsInt ?? 0, args?["z"]?.AsInt ?? 0) },
+            { "unassign_bed", args => BedTools.UnassignBed(args?["colonist"]?.Value) },
+
             // Building
             { "list_buildable", args => BuildingTools.ListBuildable(args) },
             { "get_building_info", args => BuildingTools.GetBuildingInfo(args) },


### PR DESCRIPTION
## Description
Implements bed assignment management as requested in #30.

## Changes
- Added `list_beds()` - List all beds with owners and room quality
- Added `get_bed_assignments()` - View current assignments  
- Added `assign_bed(colonist, x, z)` - Assign bed ownership
- Added `unassign_bed(colonist)` - Remove assignment

## Implementation
- Created new BedTools.cs file
- Uses `Building_Bed.TryAssignPawn()` and `Pawn.ownership.UnclaimBed()` APIs
- Handles double beds (max 2 owners), medical beds, prisoner beds
- Shows room impressiveness scores
- Detects bed sharing between colonists

## Value
AI manages housing - couples share beds, best beds for skilled colonists.

Closes #30