### PR TITLE
feat: Hunting/Taming and Resource Designation (#31, #32)

### DIFF
--- a/Source/RimMind/Tools/DesignationTools.cs
+++ b/Source/RimMind/Tools/DesignationTools.cs
@@ -1,0 +1,180 @@
+using System.Linq;
+using RimMind.API;
+using RimWorld;
+using Verse;
+
+namespace RimMind.Tools
+{
+    public static class DesignationTools
+    {
+        public static string DesignateHunt(int x, int z)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            var cell = new IntVec3(x, 0, z);
+            if (!cell.InBounds(map)) return ToolExecutor.JsonError("Coordinates out of bounds.");
+
+            var animal = cell.GetThingList(map).OfType<Pawn>().FirstOrDefault(p => p.RaceProps.Animal && !p.Faction.IsPlayer);
+            if (animal == null) return ToolExecutor.JsonError("No wild animal found at " + x + "," + z);
+
+            if (map.designationManager.DesignationOn(animal, DesignationDefOf.Hunt) != null)
+                return ToolExecutor.JsonError("Animal already designated for hunting.");
+
+            map.designationManager.AddDesignation(new Designation(animal, DesignationDefOf.Hunt));
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["animal"] = animal.LabelCap.ToString();
+            result["location"] = x + "," + z;
+            result["action"] = "hunt";
+            return result.ToString();
+        }
+
+        public static string DesignateTame(int x, int z)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            var cell = new IntVec3(x, 0, z);
+            if (!cell.InBounds(map)) return ToolExecutor.JsonError("Coordinates out of bounds.");
+
+            var animal = cell.GetThingList(map).OfType<Pawn>().FirstOrDefault(p => p.RaceProps.Animal && !p.Faction.IsPlayer);
+            if (animal == null) return ToolExecutor.JsonError("No wild animal found at " + x + "," + z);
+
+            if (!animal.RaceProps.wildness.HasValue || animal.RaceProps.wildness > 0.98f)
+                return ToolExecutor.JsonError("Animal is too wild to tame.");
+
+            if (map.designationManager.DesignationOn(animal, DesignationDefOf.Tame) != null)
+                return ToolExecutor.JsonError("Animal already designated for taming.");
+
+            map.designationManager.AddDesignation(new Designation(animal, DesignationDefOf.Tame));
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["animal"] = animal.LabelCap.ToString();
+            result["location"] = x + "," + z;
+            result["wildness"] = animal.RaceProps.wildness.HasValue ? animal.RaceProps.wildness.Value.ToString("P0") : "Unknown";
+            result["action"] = "tame";
+            return result.ToString();
+        }
+
+        public static string CancelAnimalDesignation(int x, int z)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            var cell = new IntVec3(x, 0, z);
+            if (!cell.InBounds(map)) return ToolExecutor.JsonError("Coordinates out of bounds.");
+
+            var animal = cell.GetThingList(map).OfType<Pawn>().FirstOrDefault(p => p.RaceProps.Animal);
+            if (animal == null) return ToolExecutor.JsonError("No animal found at " + x + "," + z);
+
+            var huntDes = map.designationManager.DesignationOn(animal, DesignationDefOf.Hunt);
+            var tameDes = map.designationManager.DesignationOn(animal, DesignationDefOf.Tame);
+
+            if (huntDes == null && tameDes == null)
+                return ToolExecutor.JsonError("Animal has no hunt or tame designation.");
+
+            string action = "none";
+            if (huntDes != null) { map.designationManager.RemoveDesignation(huntDes); action = "hunt"; }
+            if (tameDes != null) { map.designationManager.RemoveDesignation(tameDes); action = "tame"; }
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["animal"] = animal.LabelCap.ToString();
+            result["cancelledAction"] = action;
+            return result.ToString();
+        }
+
+        public static string DesignateMine(int x1, int z1, int x2, int z2)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            var rect = new CellRect(x1, z1, x2 - x1 + 1, z2 - z1 + 1);
+            if (!rect.InBounds(map)) return ToolExecutor.JsonError("Area out of bounds.");
+
+            int designated = 0;
+            foreach (var cell in rect.Cells)
+            {
+                var mineable = cell.GetFirstMineable(map);
+                if (mineable != null && map.designationManager.DesignationAt(cell, DesignationDefOf.Mine) == null)
+                {
+                    map.designationManager.AddDesignation(new Designation(cell, DesignationDefOf.Mine));
+                    designated++;
+                }
+            }
+
+            if (designated == 0)
+                return ToolExecutor.JsonError("No mineable rock found in area.");
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["area"] = x1 + "," + z1 + " to " + x2 + "," + z2;
+            result["cellsDesignated"] = designated;
+            result["action"] = "mine";
+            return result.ToString();
+        }
+
+        public static string DesignateChop(int x1, int z1, int x2, int z2)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            var rect = new CellRect(x1, z1, x2 - x1 + 1, z2 - z1 + 1);
+            if (!rect.InBounds(map)) return ToolExecutor.JsonError("Area out of bounds.");
+
+            int designated = 0;
+            foreach (var cell in rect.Cells)
+            {
+                var plant = cell.GetPlant(map);
+                if (plant != null && plant.def.plant.IsTree && map.designationManager.DesignationOn(plant, DesignationDefOf.CutPlant) == null)
+                {
+                    map.designationManager.AddDesignation(new Designation(plant, DesignationDefOf.CutPlant));
+                    designated++;
+                }
+            }
+
+            if (designated == 0)
+                return ToolExecutor.JsonError("No trees found in area.");
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["area"] = x1 + "," + z1 + " to " + x2 + "," + z2;
+            result["treesDesignated"] = designated;
+            result["action"] = "chop";
+            return result.ToString();
+        }
+
+        public static string DesignateHarvest(int x1, int z1, int x2, int z2)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            var rect = new CellRect(x1, z1, x2 - x1 + 1, z2 - z1 + 1);
+            if (!rect.InBounds(map)) return ToolExecutor.JsonError("Area out of bounds.");
+
+            int designated = 0;
+            foreach (var cell in rect.Cells)
+            {
+                var plant = cell.GetPlant(map);
+                if (plant != null && plant.HarvestableNow && map.designationManager.DesignationOn(plant, DesignationDefOf.HarvestPlant) == null)
+                {
+                    map.designationManager.AddDesignation(new Designation(plant, DesignationDefOf.HarvestPlant));
+                    designated++;
+                }
+            }
+
+            if (designated == 0)
+                return ToolExecutor.JsonError("No harvestable plants found in area.");
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["area"] = x1 + "," + z1 + " to " + x2 + "," + z2;
+            result["plantsDesignated"] = designated;
+            result["action"] = "harvest";
+            return result.ToString();
+        }
+    }
+}

--- a/Source/RimMind/Tools/ToolDefinitions.cs
+++ b/Source/RimMind/Tools/ToolDefinitions.cs
@@ -106,6 +106,32 @@ namespace RimMind.Tools
                 MakeParam("label", "string", "The label/name of the zone to delete"),
                 MakeOptionalParam("remove_plans", "boolean", "Also remove plan designations in the area (planning zones only, default: false)")));
 
+            // Designation Tools (Hunting/Taming/Resource Gathering)
+            tools.Add(MakeTool("designate_hunt", "Mark a wild animal for hunting. Use get_map_region to find animals.",
+                MakeParam("x", "integer", "Animal X coordinate"),
+                MakeParam("z", "integer", "Animal Z coordinate")));
+            tools.Add(MakeTool("designate_tame", "Mark a wild animal for taming. Animal must not be too wild.",
+                MakeParam("x", "integer", "Animal X coordinate"),
+                MakeParam("z", "integer", "Animal Z coordinate")));
+            tools.Add(MakeTool("cancel_animal_designation", "Cancel hunt or tame designation on an animal.",
+                MakeParam("x", "integer", "Animal X coordinate"),
+                MakeParam("z", "integer", "Animal Z coordinate")));
+            tools.Add(MakeTool("designate_mine", "Mark rocks for mining in an area.",
+                MakeParam("x1", "integer", "Start X coordinate"),
+                MakeParam("z1", "integer", "Start Z coordinate"),
+                MakeParam("x2", "integer", "End X coordinate"),
+                MakeParam("z2", "integer", "End Z coordinate")));
+            tools.Add(MakeTool("designate_chop", "Mark trees for chopping in an area.",
+                MakeParam("x1", "integer", "Start X coordinate"),
+                MakeParam("z1", "integer", "Start Z coordinate"),
+                MakeParam("x2", "integer", "End X coordinate"),
+                MakeParam("z2", "integer", "End Z coordinate")));
+            tools.Add(MakeTool("designate_harvest", "Mark plants for harvesting in an area.",
+                MakeParam("x1", "integer", "Start X coordinate"),
+                MakeParam("z1", "integer", "Start Z coordinate"),
+                MakeParam("x2", "integer", "End X coordinate"),
+                MakeParam("z2", "integer", "End Z coordinate")));
+
             // Building Tools
             tools.Add(MakeTool("list_buildable", "List available buildings that can be constructed. Shows defName, label, size, material requirements, and research status. Use 'category' to filter (Structure, Furniture, Production, Power, Security, Temperature, Misc, Joy). Without filter, shows all buildings grouped by category.",
                 MakeOptionalParam("category", "string", "Filter by building category (e.g., 'Structure', 'Furniture', 'Production', 'Power', 'Security')")));

--- a/Source/RimMind/Tools/ToolExecutor.cs
+++ b/Source/RimMind/Tools/ToolExecutor.cs
@@ -67,6 +67,14 @@ namespace RimMind.Tools
             { "create_zone", args => ZoneTools.CreateZone(args) },
             { "delete_zone", args => ZoneTools.DeleteZone(args) },
 
+            // Designations
+            { "designate_hunt", args => DesignationTools.DesignateHunt(args?["x"]?.AsInt ?? 0, args?["z"]?.AsInt ?? 0) },
+            { "designate_tame", args => DesignationTools.DesignateTame(args?["x"]?.AsInt ?? 0, args?["z"]?.AsInt ?? 0) },
+            { "cancel_animal_designation", args => DesignationTools.CancelAnimalDesignation(args?["x"]?.AsInt ?? 0, args?["z"]?.AsInt ?? 0) },
+            { "designate_mine", args => DesignationTools.DesignateMine(args?["x1"]?.AsInt ?? 0, args?["z1"]?.AsInt ?? 0, args?["x2"]?.AsInt ?? 0, args?["z2"]?.AsInt ?? 0) },
+            { "designate_chop", args => DesignationTools.DesignateChop(args?["x1"]?.AsInt ?? 0, args?["z1"]?.AsInt ?? 0, args?["x2"]?.AsInt ?? 0, args?["z2"]?.AsInt ?? 0) },
+            { "designate_harvest", args => DesignationTools.DesignateHarvest(args?["x1"]?.AsInt ?? 0, args?["z1"]?.AsInt ?? 0, args?["x2"]?.AsInt ?? 0, args?["z2"]?.AsInt ?? 0) },
+
             // Building
             { "list_buildable", args => BuildingTools.ListBuildable(args) },
             { "get_building_info", args => BuildingTools.GetBuildingInfo(args) },


### PR DESCRIPTION
## Description
Implements hunting/taming and resource gathering designations as requested in #31 and #32.

## Changes
### Hunting/Taming (#31)
- Added `designate_hunt(x, z)` - Mark animal for hunting
- Added `designate_tame(x, z)` - Mark animal for taming  
- Added `cancel_animal_designation(x, z)` - Cancel orders

### Resource Gathering (#32)
- Added `designate_mine(x1, z1, x2, z2)` - Mine rocks
- Added `designate_chop(x1, z1, x2, z2)` - Chop trees
- Added `designate_harvest(x1, z1, x2, z2)` - Harvest plants

## Implementation
- Created new DesignationTools.cs file
- Uses `DesignationManager.AddDesignation()` API
- Validates wildness for taming, checks for existing designations
- Area-based designation for resource gathering
- Returns counts of designated cells/items

## Value
AI manages wildlife and resources - 'hunt deer for food', 'tame that husky', 'mine that steel vein', 'clear trees for expansion'.

Closes #31
Closes #32