### PR TITLE
feat: add trade analysis tools (#15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,16 +242,20 @@ RimMind/
 - **Animals** (2): list_animals, get_animal_details
 - **Events** (2): get_recent_events, get_active_alerts
 - **Medical** (1): get_medical_overview
+- **HealthCheck** (1): colony_health_check
+- **Mood** (2): get_mood_risks, suggest_mood_interventions
 - **Directives** (3): get_directives, add_directive, remove_directive
 - **Plan** (3): get_plans, place_plans, remove_plans
 - **Zone** (3): list_zones, create_zone, delete_zone
 - **Building** (6): list_buildable, get_building_info, place_building, place_structure, remove_building, approve_buildings
 - **Area** (4): list_areas, get_area_restrictions, restrict_to_area, unrestrict
+- **Trade** (2): get_active_traders, analyze_trade_opportunity
 
 ## Development Rules
 - **Keep this file updated.** Every time a feature is built, a bug is fixed, or a tool is added, update the relevant sections of this CLAUDE.md. This file is the living index of the project — future AI sessions rely on it to understand what exists, how it works, and what has changed.
 
 ## Changelog
+- **2026-02-16**: Added trade analysis tools (`get_active_traders`, `analyze_trade_opportunity`) — AI can now discover all available traders (orbital ships, visiting caravans, allied settlements in comms range) with full inventory details, buy/sell prices, and departure times. Trade opportunity analysis compares colony resources against trader inventory to suggest profitable trades: urgent purchases (medicine, components, food when low), profitable sales (surplus materials), and strategic acquisitions (high-value items like plasteel, advanced components). Returns prioritized recommendations with utility scores and reasoning.
 - **2026-02-15**: Added `get_map_region` tool — character-grid map visualization with 28 cell codes for buildings, pawns, items, zones, terrain. Supports full map or sub-region queries.
 - **2026-02-15**: Added `get_cell_details` tool — drill-down for single cell or range (up to 15x15). Returns terrain, roof, temperature, fertility, room stats, zone, and all things present.
 - **2026-02-15**: Fixed Enter key in chat window — overrode `OnAcceptKeyPressed()` and set `forceCatchAcceptAndCancelEventEvenIfUnfocused = true`. RimWorld's `WindowStack.Notify_PressedAccept` skips windows where both `closeOnAccept` and `forceCatch` are false. The keybinding system consumes Return before `DoWindowContents` runs, so KeyDown handlers there never see it.

--- a/Source/RimMind/Tools/HealthCheckTools.cs
+++ b/Source/RimMind/Tools/HealthCheckTools.cs
@@ -1,0 +1,738 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using RimMind.API;
+using RimWorld;
+using Verse;
+
+namespace RimMind.Tools
+{
+    public static class HealthCheckTools
+    {
+        public static string ColonyHealthCheck()
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            var result = new JSONObject();
+            result["timestamp"] = GenDate.DateFullStringWithHourAt(GenTicks.TicksAbs, Find.WorldGrid.LongLatOf(map.Tile));
+            
+            var systems = new JSONArray();
+            var criticalAlerts = new JSONArray();
+            var topRecommendations = new List<string>();
+
+            // Track overall status (healthy/stable/warning/critical)
+            string worstStatus = "healthy";
+
+            // 1. FOOD SECURITY
+            var foodSystem = CheckFoodSecurity(map, criticalAlerts, topRecommendations);
+            systems.Add(foodSystem);
+            worstStatus = GetWorstStatus(worstStatus, foodSystem["status"].Value);
+
+            // 2. POWER GRID
+            var powerSystem = CheckPowerGrid(map, criticalAlerts, topRecommendations);
+            systems.Add(powerSystem);
+            worstStatus = GetWorstStatus(worstStatus, powerSystem["status"].Value);
+
+            // 3. DEFENSE READINESS
+            var defenseSystem = CheckDefenseReadiness(map, criticalAlerts, topRecommendations);
+            systems.Add(defenseSystem);
+            worstStatus = GetWorstStatus(worstStatus, defenseSystem["status"].Value);
+
+            // 4. COLONIST WELLBEING
+            var wellbeingSystem = CheckColonistWellbeing(map, criticalAlerts, topRecommendations);
+            systems.Add(wellbeingSystem);
+            worstStatus = GetWorstStatus(worstStatus, wellbeingSystem["status"].Value);
+
+            // 5. RESOURCE BOTTLENECKS
+            var resourcesSystem = CheckResourceBottlenecks(map, criticalAlerts, topRecommendations);
+            systems.Add(resourcesSystem);
+            worstStatus = GetWorstStatus(worstStatus, resourcesSystem["status"].Value);
+
+            // 6. RESEARCH PROGRESS
+            var researchSystem = CheckResearchProgress(criticalAlerts, topRecommendations);
+            systems.Add(researchSystem);
+            worstStatus = GetWorstStatus(worstStatus, researchSystem["status"].Value);
+
+            // 7. HOUSING QUALITY
+            var housingSystem = CheckHousingQuality(map, criticalAlerts, topRecommendations);
+            systems.Add(housingSystem);
+            worstStatus = GetWorstStatus(worstStatus, housingSystem["status"].Value);
+
+            // 8. PRODUCTION ISSUES
+            var productionSystem = CheckProductionIssues(map, criticalAlerts, topRecommendations);
+            systems.Add(productionSystem);
+            worstStatus = GetWorstStatus(worstStatus, productionSystem["status"].Value);
+
+            result["overall_status"] = worstStatus;
+            result["summary"] = GenerateSummary(worstStatus, criticalAlerts.Count);
+            result["systems"] = systems;
+            result["critical_alerts"] = criticalAlerts;
+            
+            // Take top 5 recommendations
+            var topRecsArray = new JSONArray();
+            for (int i = 0; i < Math.Min(5, topRecommendations.Count); i++)
+                topRecsArray.Add(topRecommendations[i]);
+            result["top_recommendations"] = topRecsArray;
+
+            return result.ToString();
+        }
+
+        private static JSONObject CheckFoodSecurity(Map map, JSONArray criticalAlerts, List<string> recommendations)
+        {
+            var system = new JSONObject();
+            system["name"] = "Food Security";
+            var issues = new JSONArray();
+            var recs = new JSONArray();
+
+            // Calculate food availability
+            float totalNutrition = map.resourceCounter.TotalHumanEdibleNutrition;
+            int colonistCount = map.mapPawns.FreeColonistsCount;
+            float daysOfFood = colonistCount > 0 ? totalNutrition / (colonistCount * 2f) : 999f; // ~2 nutrition per colonist per day
+
+            // Growing zones
+            int growingZones = map.zoneManager.AllZones.OfType<Zone_Growing>().Count();
+            int activeGrowingZones = map.zoneManager.AllZones.OfType<Zone_Growing>()
+                .Count(z => z.GetPlantDefToGrow() != null && map.mapTemperature.SeasonalTemp > 0);
+
+            // Hunting capability (wild animals on map)
+            int huntableAnimals = map.mapPawns.AllPawnsSpawned
+                .Count(p => p.RaceProps.Animal && p.Faction == null && p.RaceProps.baseBodySize >= 0.5f);
+
+            // Determine status
+            string status = "healthy";
+            if (daysOfFood < 3)
+            {
+                status = "critical";
+                criticalAlerts.Add("Only " + daysOfFood.ToString("F1") + " days of food remaining!");
+                recommendations.Insert(0, "URGENT: Hunt animals, harvest crops, or buy food immediately");
+            }
+            else if (daysOfFood < 7)
+            {
+                status = "warning";
+                issues.Add("Low food reserves (" + daysOfFood.ToString("F1") + " days)");
+                recs.Add("Increase food production or stockpiles");
+            }
+
+            if (activeGrowingZones == 0 && growingZones > 0)
+            {
+                issues.Add("Growing zones exist but none are active (wrong season or no plants assigned)");
+                recs.Add("Check growing zone crop assignments");
+            }
+
+            if (growingZones == 0 && colonistCount > 3)
+            {
+                issues.Add("No growing zones established");
+                recs.Add("Create growing zones to ensure long-term food security");
+                if (status == "healthy") status = "stable";
+            }
+
+            string details = daysOfFood.ToString("F1") + " days of food, " + 
+                            activeGrowingZones + "/" + growingZones + " growing zones active";
+            if (huntableAnimals > 0)
+                details += ", " + huntableAnimals + " huntable animals nearby";
+
+            system["status"] = status;
+            system["details"] = details;
+            system["issues"] = issues;
+            system["recommendations"] = recs;
+            
+            foreach (var rec in recs.AsArray) recommendations.Add(rec.Value);
+
+            return system;
+        }
+
+        private static JSONObject CheckPowerGrid(Map map, JSONArray criticalAlerts, List<string> recommendations)
+        {
+            var system = new JSONObject();
+            system["name"] = "Power Grid";
+            var issues = new JSONArray();
+            var recs = new JSONArray();
+
+            float totalGeneration = 0;
+            float totalConsumption = 0;
+            float totalStored = 0;
+            float totalStorageCapacity = 0;
+            int batteryCount = 0;
+
+            var nets = map.powerNetManager.AllNetsListForReading;
+            foreach (var net in nets)
+            {
+                foreach (var comp in net.powerComps)
+                {
+                    if (comp.PowerOn)
+                    {
+                        if (comp.PowerOutput > 0)
+                            totalGeneration += comp.PowerOutput;
+                        else
+                            totalConsumption += -comp.PowerOutput;
+                    }
+                }
+
+                foreach (var battery in net.batteryComps)
+                {
+                    totalStored += battery.StoredEnergy;
+                    totalStorageCapacity += battery.Props.storedEnergyMax;
+                    batteryCount++;
+                }
+            }
+
+            float surplus = totalGeneration - totalConsumption;
+            float batteryPercent = totalStorageCapacity > 0 ? (totalStored / totalStorageCapacity * 100f) : 0;
+
+            // Determine status
+            string status = "healthy";
+            
+            if (surplus < 0)
+            {
+                status = "critical";
+                criticalAlerts.Add("Power deficit: " + (-surplus).ToString("F0") + "W shortfall!");
+                recommendations.Insert(0, "URGENT: Build more generators or disable non-essential power consumers");
+            }
+            else if (surplus < 500 && totalConsumption > 1000)
+            {
+                status = "warning";
+                issues.Add("Low power margin (" + surplus.ToString("F0") + "W surplus)");
+                recs.Add("Add backup power generation");
+            }
+
+            if (batteryCount == 0 && totalGeneration > 0)
+            {
+                issues.Add("No batteries - vulnerable to night/eclipse brownouts");
+                recs.Add("Build batteries for power storage");
+                if (status == "healthy") status = "stable";
+            }
+            else if (batteryPercent < 20 && batteryCount > 0)
+            {
+                issues.Add("Battery reserves low (" + batteryPercent.ToString("F0") + "%)");
+                if (status == "healthy") status = "warning";
+            }
+
+            if (totalGeneration == 0 && totalConsumption > 0)
+            {
+                status = "critical";
+                criticalAlerts.Add("No power generation!");
+            }
+
+            string details = totalGeneration.ToString("F0") + "W generation, " + 
+                           totalConsumption.ToString("F0") + "W consumption, " +
+                           surplus.ToString("F0") + "W surplus";
+            if (batteryCount > 0)
+                details += ", " + batteryCount + " batteries at " + batteryPercent.ToString("F0") + "%";
+
+            system["status"] = status;
+            system["details"] = details;
+            system["issues"] = issues;
+            system["recommendations"] = recs;
+            
+            foreach (var rec in recs.AsArray) recommendations.Add(rec.Value);
+
+            return system;
+        }
+
+        private static JSONObject CheckDefenseReadiness(Map map, JSONArray criticalAlerts, List<string> recommendations)
+        {
+            var system = new JSONObject();
+            system["name"] = "Defense Readiness";
+            var issues = new JSONArray();
+            var recs = new JSONArray();
+
+            // Turrets
+            int turrets = map.listerBuildings.allBuildingsColonist.OfType<Building_TurretGun>().Count();
+
+            // Traps
+            int traps = map.listerBuildings.allBuildingsColonist
+                .Count(b => b.def.building != null && b.def.building.isTrap);
+
+            // Combat-capable colonists (armed or decent combat skills)
+            int combatCapable = 0;
+            int armed = 0;
+            foreach (var pawn in map.mapPawns.FreeColonists)
+            {
+                if (pawn.Downed || pawn.Dead) continue;
+                
+                bool hasWeapon = pawn.equipment?.Primary != null;
+                if (hasWeapon) armed++;
+
+                int shootSkill = pawn.skills?.GetSkill(SkillDefOf.Shooting)?.Level ?? 0;
+                int meleeSkill = pawn.skills?.GetSkill(SkillDefOf.Melee)?.Level ?? 0;
+                
+                if (hasWeapon || shootSkill >= 5 || meleeSkill >= 5)
+                    combatCapable++;
+            }
+
+            // Weapon stockpile
+            int weaponStock = map.listerThings.ThingsInGroup(ThingRequestGroup.Weapon)
+                .Count(t => t.Faction == Faction.OfPlayer || !t.Position.Fogged(map));
+
+            // Determine status
+            string status = "healthy";
+            int colonistCount = map.mapPawns.FreeColonistsCount;
+
+            if (combatCapable == 0 && colonistCount > 0)
+            {
+                status = "critical";
+                criticalAlerts.Add("No combat-capable colonists!");
+                recommendations.Insert(0, "URGENT: Arm colonists and assign weapon training");
+            }
+            else if (combatCapable < colonistCount / 2)
+            {
+                status = "warning";
+                issues.Add("Less than half of colonists are combat-ready");
+                recs.Add("Arm more colonists or train combat skills");
+            }
+
+            if (turrets == 0 && colonistCount > 3)
+            {
+                issues.Add("No defensive turrets");
+                recs.Add("Build turrets for base defense");
+                if (status == "healthy") status = "stable";
+            }
+
+            if (armed < colonistCount / 2)
+            {
+                issues.Add("Many colonists are unarmed");
+                recs.Add("Craft or purchase weapons for colonists");
+            }
+
+            string details = combatCapable + "/" + colonistCount + " combat-capable colonists, " +
+                           turrets + " turrets, " + traps + " traps, " +
+                           weaponStock + " weapons in stockpile";
+
+            system["status"] = status;
+            system["details"] = details;
+            system["issues"] = issues;
+            system["recommendations"] = recs;
+            
+            foreach (var rec in recs.AsArray) recommendations.Add(rec.Value);
+
+            return system;
+        }
+
+        private static JSONObject CheckColonistWellbeing(Map map, JSONArray criticalAlerts, List<string> recommendations)
+        {
+            var system = new JSONObject();
+            system["name"] = "Colonist Wellbeing";
+            var issues = new JSONArray();
+            var recs = new JSONArray();
+
+            int totalColonists = map.mapPawns.FreeColonistsCount;
+            int injured = 0;
+            int diseased = 0;
+            int moodRisk = 0;
+            int starving = 0;
+            int exhausted = 0;
+            int mentalBreak = 0;
+
+            foreach (var pawn in map.mapPawns.FreeColonists)
+            {
+                // Health issues
+                if (pawn.health.HasHediffsNeedingTend())
+                    injured++;
+
+                var diseases = pawn.health.hediffSet.hediffs
+                    .Where(h => h.def.makesSickThought || h.def.lethalSeverity > 0);
+                if (diseases.Any())
+                    diseased++;
+
+                // Mood
+                float moodLevel = pawn.needs?.mood?.CurLevelPercentage ?? 1f;
+                if (moodLevel < 0.3f)
+                    moodRisk++;
+
+                // Needs
+                float foodLevel = pawn.needs?.food?.CurLevelPercentage ?? 1f;
+                if (foodLevel < 0.2f)
+                    starving++;
+
+                float restLevel = pawn.needs?.rest?.CurLevelPercentage ?? 1f;
+                if (restLevel < 0.2f)
+                    exhausted++;
+
+                // Mental state
+                if (pawn.InMentalState)
+                    mentalBreak++;
+            }
+
+            // Determine status
+            string status = "healthy";
+
+            if (mentalBreak > 0)
+            {
+                status = "warning";
+                issues.Add(mentalBreak + " colonist(s) in mental break");
+                recs.Add("Address mood issues and give colonists breaks");
+            }
+
+            if (starving > 0)
+            {
+                status = "critical";
+                criticalAlerts.Add(starving + " colonist(s) starving!");
+                recommendations.Insert(0, "URGENT: Feed colonists immediately");
+            }
+
+            if (moodRisk > 0)
+            {
+                if (status == "healthy") status = "warning";
+                issues.Add(moodRisk + " colonist(s) at risk of mental break (mood < 30%)");
+                recs.Add("Improve mood through better food, recreation, or room quality");
+            }
+
+            if (diseased > 0)
+            {
+                issues.Add(diseased + " colonist(s) with disease");
+                recs.Add("Ensure adequate medical care and medicine supply");
+                if (status == "healthy") status = "stable";
+            }
+
+            if (injured > totalColonists / 3)
+            {
+                if (status == "healthy") status = "warning";
+                issues.Add("Many colonists need medical treatment");
+                recs.Add("Prioritize medical care");
+            }
+
+            if (exhausted > 0)
+            {
+                issues.Add(exhausted + " colonist(s) exhausted");
+                recs.Add("Check work schedules - ensure colonists get adequate sleep");
+            }
+
+            string details = "Healthy: " + (totalColonists - injured - diseased) + "/" + totalColonists;
+            if (injured > 0) details += ", " + injured + " injured";
+            if (diseased > 0) details += ", " + diseased + " diseased";
+            if (moodRisk > 0) details += ", " + moodRisk + " mood risk";
+
+            system["status"] = status;
+            system["details"] = details;
+            system["issues"] = issues;
+            system["recommendations"] = recs;
+            
+            foreach (var rec in recs.AsArray) recommendations.Add(rec.Value);
+
+            return system;
+        }
+
+        private static JSONObject CheckResourceBottlenecks(Map map, JSONArray criticalAlerts, List<string> recommendations)
+        {
+            var system = new JSONObject();
+            system["name"] = "Resource Bottlenecks";
+            var issues = new JSONArray();
+            var recs = new JSONArray();
+
+            // Check critical resources
+            var shortages = new Dictionary<string, int>();
+            var thresholds = new Dictionary<string, int>
+            {
+                { "Steel", 200 },
+                { "WoodLog", 300 },
+                { "ComponentIndustrial", 20 },
+                { "MedicineIndustrial", 10 },
+                { "Silver", 500 },
+                { "Plasteel", 50 }
+            };
+
+            foreach (var item in thresholds)
+            {
+                var def = DefDatabase<ThingDef>.GetNamedSilentFail(item.Key);
+                if (def != null)
+                {
+                    int count = map.listerThings.ThingsOfDef(def).Sum(t => t.stackCount);
+                    if (count < item.Value)
+                        shortages[item.Key] = count;
+                }
+            }
+
+            // Determine status
+            string status = "healthy";
+            
+            if (shortages.ContainsKey("Steel") && shortages["Steel"] < 50)
+            {
+                status = "critical";
+                criticalAlerts.Add("Critically low on steel (" + shortages["Steel"] + ")!");
+                recommendations.Insert(0, "URGENT: Mine steel or trade for materials");
+            }
+            else if (shortages.ContainsKey("Steel"))
+            {
+                status = "warning";
+                issues.Add("Low steel reserves (" + shortages["Steel"] + ")");
+                recs.Add("Mine more steel deposits");
+            }
+
+            if (shortages.ContainsKey("MedicineIndustrial") && shortages["MedicineIndustrial"] < 5)
+            {
+                if (status == "healthy") status = "warning";
+                issues.Add("Low medicine (" + shortages["MedicineIndustrial"] + ")");
+                recs.Add("Craft or purchase medicine");
+            }
+
+            if (shortages.ContainsKey("ComponentIndustrial") && shortages["ComponentIndustrial"] < 10)
+            {
+                if (status == "healthy") status = "warning";
+                issues.Add("Low components (" + shortages["ComponentIndustrial"] + ")");
+                recs.Add("Deconstruct mechanoids or trade for components");
+            }
+
+            if (shortages.Count > 3)
+            {
+                if (status == "healthy") status = "stable";
+                issues.Add("Multiple resource shortages detected");
+                recs.Add("Diversify resource gathering and trading");
+            }
+
+            string details = shortages.Count > 0 
+                ? "Shortages: " + string.Join(", ", shortages.Select(s => s.Key + "(" + s.Value + ")"))
+                : "All critical resources adequately stocked";
+
+            system["status"] = status;
+            system["details"] = details;
+            system["issues"] = issues;
+            system["recommendations"] = recs;
+            
+            foreach (var rec in recs.AsArray) recommendations.Add(rec.Value);
+
+            return system;
+        }
+
+        private static JSONObject CheckResearchProgress(JSONArray criticalAlerts, List<string> recommendations)
+        {
+            var system = new JSONObject();
+            system["name"] = "Research Progress";
+            var issues = new JSONArray();
+            var recs = new JSONArray();
+
+            var manager = Find.ResearchManager;
+            var currentProject = manager.GetProject();
+
+            string status = "healthy";
+            string details = "";
+
+            if (currentProject != null)
+            {
+                float progress = manager.GetProgress(currentProject) / currentProject.baseCost * 100f;
+                details = "Researching: " + currentProject.LabelCap + " (" + progress.ToString("F0") + "%)";
+                
+                // Check if we have research benches
+                var map = Find.CurrentMap;
+                if (map != null)
+                {
+                    int benches = map.listerBuildings.allBuildingsColonist
+                        .Count(b => b.def.defName.Contains("ResearchBench"));
+                    
+                    if (benches == 0)
+                    {
+                        status = "warning";
+                        issues.Add("Research project active but no research benches found");
+                        recs.Add("Build a research bench to enable research");
+                    }
+                }
+            }
+            else
+            {
+                status = "stable";
+                issues.Add("No active research project");
+                recs.Add("Select a research project to improve colony technology");
+                details = "No active research";
+            }
+
+            system["status"] = status;
+            system["details"] = details;
+            system["issues"] = issues;
+            system["recommendations"] = recs;
+            
+            foreach (var rec in recs.AsArray) recommendations.Add(rec.Value);
+
+            return system;
+        }
+
+        private static JSONObject CheckHousingQuality(Map map, JSONArray criticalAlerts, List<string> recommendations)
+        {
+            var system = new JSONObject();
+            system["name"] = "Housing Quality";
+            var issues = new JSONArray();
+            var recs = new JSONArray();
+
+            int colonistCount = map.mapPawns.FreeColonistsCount;
+            int beds = 0;
+            int privateBeds = 0;
+            int barracksStyleBeds = 0;
+            int badBedroomCount = 0;
+
+            // Track colonists with beds
+            var colonistsWithBeds = new HashSet<Pawn>();
+
+            // Check all beds
+            foreach (var building in map.listerBuildings.allBuildingsColonist)
+            {
+                if (building is Building_Bed bed && !bed.Medical)
+                {
+                    beds++;
+                    
+                    foreach (var owner in bed.OwnersForReading)
+                        colonistsWithBeds.Add(owner);
+
+                    var room = bed.GetRoom();
+                    if (room != null && !room.OutdoorNow)
+                    {
+                        int bedsInRoom = room.ContainedBeds.Count();
+                        if (bedsInRoom == 1)
+                            privateBeds++;
+                        else
+                            barracksStyleBeds++;
+
+                        float impressiveness = room.GetStat(RoomStatDefOf.Impressiveness);
+                        if (impressiveness < 20)
+                            badBedroomCount++;
+                    }
+                }
+            }
+
+            int colonistsWithoutBeds = colonistCount - colonistsWithBeds.Count;
+
+            // Determine status
+            string status = "healthy";
+
+            if (colonistsWithoutBeds > 0)
+            {
+                status = "warning";
+                issues.Add(colonistsWithoutBeds + " colonist(s) without assigned beds");
+                recs.Add("Build more beds and assign to colonists");
+            }
+
+            if (badBedroomCount > colonistCount / 2)
+            {
+                if (status == "healthy") status = "stable";
+                issues.Add("Many bedrooms have low impressiveness (< 20)");
+                recs.Add("Improve bedroom quality with better floors, decorations, or larger rooms");
+            }
+
+            if (barracksStyleBeds > privateBeds && colonistCount > 3)
+            {
+                if (status == "healthy") status = "stable";
+                issues.Add("Most colonists in shared bedrooms (barracks)");
+                recs.Add("Build private bedrooms to improve colonist mood");
+            }
+
+            string details = beds + " beds total, " + privateBeds + " private, " + 
+                           barracksStyleBeds + " in barracks";
+            if (colonistsWithoutBeds > 0)
+                details += ", " + colonistsWithoutBeds + " colonists unassigned";
+
+            system["status"] = status;
+            system["details"] = details;
+            system["issues"] = issues;
+            system["recommendations"] = recs;
+            
+            foreach (var rec in recs.AsArray) recommendations.Add(rec.Value);
+
+            return system;
+        }
+
+        private static JSONObject CheckProductionIssues(Map map, JSONArray criticalAlerts, List<string> recommendations)
+        {
+            var system = new JSONObject();
+            system["name"] = "Production Issues";
+            var issues = new JSONArray();
+            var recs = new JSONArray();
+
+            int totalBills = 0;
+            int suspendedBills = 0;
+            int billsWithoutWorkers = 0;
+
+            // Check all workbenches
+            foreach (var building in map.listerBuildings.allBuildingsColonist)
+            {
+                if (building is Building_WorkTable workTable && workTable.BillStack != null)
+                {
+                    foreach (var bill in workTable.BillStack.Bills)
+                    {
+                        totalBills++;
+
+                        if (bill.suspended)
+                            suspendedBills++;
+
+                        // Check if anyone can do this work
+                        if (bill.recipe?.workSkill != null)
+                        {
+                            var workType = bill.recipe.workSkill.workTags.ToString();
+                            bool hasWorker = map.mapPawns.FreeColonists
+                                .Any(p => !p.WorkTypeIsDisabled(DefDatabase<WorkTypeDef>.AllDefs
+                                    .FirstOrDefault(wt => wt.relevantSkills.Contains(bill.recipe.workSkill))));
+                            
+                            if (!hasWorker)
+                                billsWithoutWorkers++;
+                        }
+                    }
+                }
+            }
+
+            // Determine status
+            string status = "healthy";
+
+            if (billsWithoutWorkers > 0)
+            {
+                status = "warning";
+                issues.Add(billsWithoutWorkers + " bill(s) have no assigned workers");
+                recs.Add("Enable work types for colonists or assign workers to production bills");
+            }
+
+            if (suspendedBills > totalBills / 2 && totalBills > 0)
+            {
+                if (status == "healthy") status = "stable";
+                issues.Add("Many production bills are suspended");
+                recs.Add("Review and resume important production bills");
+            }
+
+            if (totalBills == 0)
+            {
+                if (status == "healthy") status = "stable";
+                details = "No active production bills";
+            }
+            else
+            {
+                string details = totalBills + " total bills";
+                if (suspendedBills > 0)
+                    details += ", " + suspendedBills + " suspended";
+                if (billsWithoutWorkers > 0)
+                    details += ", " + billsWithoutWorkers + " without workers";
+                system["details"] = details;
+            }
+
+            system["status"] = status;
+            system["details"] = totalBills > 0 
+                ? totalBills + " active bills, " + suspendedBills + " suspended"
+                : "No production bills configured";
+            system["issues"] = issues;
+            system["recommendations"] = recs;
+            
+            foreach (var rec in recs.AsArray) recommendations.Add(rec.Value);
+
+            return system;
+        }
+
+        private static string GetWorstStatus(string current, string newStatus)
+        {
+            // critical > warning > stable > healthy
+            if (current == "critical" || newStatus == "critical") return "critical";
+            if (current == "warning" || newStatus == "warning") return "warning";
+            if (current == "stable" || newStatus == "stable") return "stable";
+            return "healthy";
+        }
+
+        private static string GenerateSummary(string status, int criticalCount)
+        {
+            switch (status)
+            {
+                case "critical":
+                    return "Colony in CRITICAL condition - " + criticalCount + " urgent issue(s) require immediate attention!";
+                case "warning":
+                    return "Colony stable but facing challenges - address warnings before they become critical";
+                case "stable":
+                    return "Colony functioning adequately with room for improvement";
+                case "healthy":
+                default:
+                    return "Colony in good health - all systems functioning well";
+            }
+        }
+    }
+}

--- a/Source/RimMind/Tools/MoodTools.cs
+++ b/Source/RimMind/Tools/MoodTools.cs
@@ -1,0 +1,414 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using RimMind.API;
+using RimWorld;
+using Verse;
+using Verse.AI;
+
+namespace RimMind.Tools
+{
+    public static class MoodTools
+    {
+        public static string GetMoodRisks()
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            var result = new JSONObject();
+            var atRiskColonists = new JSONArray();
+
+            foreach (var pawn in map.mapPawns.FreeColonists)
+            {
+                if (pawn.needs?.mood == null) continue;
+
+                var need_mood = pawn.needs.mood;
+                float moodLevel = need_mood.CurLevel;
+                float moodPercentage = need_mood.CurLevelPercentage;
+
+                // Get break thresholds
+                float breakThresholdMinor = pawn.mindState.mentalBreaker.BreakThresholdMinor;
+                float breakThresholdMajor = pawn.mindState.mentalBreaker.BreakThresholdMajor;
+                float breakThresholdExtreme = pawn.mindState.mentalBreaker.BreakThresholdExtreme;
+
+                // Calculate risk level based on how close to break threshold
+                string riskLevel = null;
+                float distanceToBreak = moodLevel - breakThresholdExtreme;
+
+                if (moodLevel <= breakThresholdExtreme)
+                    riskLevel = "critical";
+                else if (moodLevel <= breakThresholdMajor)
+                    riskLevel = "high";
+                else if (moodLevel <= breakThresholdMinor)
+                    riskLevel = "medium";
+                else if (moodLevel < 0.35f) // Still worth flagging if mood is low
+                    riskLevel = "low";
+
+                // Only include pawns with some level of risk
+                if (riskLevel != null)
+                {
+                    var colonist = new JSONObject();
+                    colonist["name"] = pawn.Name?.ToStringShort ?? "Unknown";
+                    colonist["moodLevel"] = moodPercentage.ToString("P0");
+                    colonist["moodValue"] = moodLevel.ToString("0.00");
+                    colonist["riskLevel"] = riskLevel;
+                    colonist["breakThresholdExtreme"] = breakThresholdExtreme.ToString("0.00");
+                    colonist["breakThresholdMajor"] = breakThresholdMajor.ToString("0.00");
+                    colonist["breakThresholdMinor"] = breakThresholdMinor.ToString("0.00");
+                    colonist["distanceToBreak"] = distanceToBreak.ToString("0.00");
+
+                    // Current mental state
+                    if (pawn.MentalStateDef != null)
+                        colonist["currentMentalState"] = pawn.MentalStateDef.label;
+
+                    // Get negative thoughts
+                    var negativeThoughts = new JSONArray();
+                    if (need_mood.thoughts?.memories?.Memories != null)
+                    {
+                        foreach (var memory in need_mood.thoughts.memories.Memories)
+                        {
+                            float moodEffect = memory.MoodOffset();
+                            if (moodEffect < 0)
+                            {
+                                var thought = new JSONObject();
+                                thought["label"] = memory.LabelCap.ToString();
+                                thought["moodEffect"] = moodEffect.ToString("+0.#;-0.#");
+                                thought["age"] = memory.age.ToString();
+                                thought["daysRemaining"] = ((memory.def.DurationTicks - memory.age) / 60000f).ToString("0.0");
+                                negativeThoughts.Add(thought);
+                            }
+                        }
+                    }
+                    if (negativeThoughts.Count > 0)
+                        colonist["negativeThoughts"] = negativeThoughts;
+
+                    // Check for traits that affect mental breaks
+                    var riskTraits = new JSONArray();
+                    if (pawn.story?.traits != null)
+                    {
+                        foreach (var trait in pawn.story.traits.allTraits)
+                        {
+                            // Traits that make mental breaks more likely or more severe
+                            if (trait.def.defName == "Neurotic" || 
+                                trait.def.defName == "Volatile" ||
+                                trait.def.defName == "Depressive" ||
+                                trait.def.defName == "PsychicallySensitive" ||
+                                trait.def.defName == "Pessimist")
+                            {
+                                riskTraits.Add(trait.LabelCap.ToString());
+                            }
+                        }
+                    }
+                    if (riskTraits.Count > 0)
+                        colonist["riskTraits"] = riskTraits;
+
+                    // Estimate time to break (very rough)
+                    // Calculate recent mood trend if possible
+                    float estimatedDaysToBreak = -1;
+                    if (moodLevel > breakThresholdExtreme && distanceToBreak > 0)
+                    {
+                        // Average mood loss from current thoughts
+                        float totalNegativeMood = 0;
+                        int negativeCount = 0;
+                        if (need_mood.thoughts?.memories?.Memories != null)
+                        {
+                            foreach (var memory in need_mood.thoughts.memories.Memories)
+                            {
+                                float effect = memory.MoodOffset();
+                                if (effect < 0)
+                                {
+                                    totalNegativeMood += effect;
+                                    negativeCount++;
+                                }
+                            }
+                        }
+
+                        if (negativeCount > 0)
+                        {
+                            float avgDailyMoodLoss = Math.Abs(totalNegativeMood) / 10f; // Rough estimate
+                            if (avgDailyMoodLoss > 0.01f)
+                            {
+                                estimatedDaysToBreak = distanceToBreak / avgDailyMoodLoss;
+                            }
+                        }
+                    }
+                    
+                    if (estimatedDaysToBreak > 0)
+                        colonist["estimatedDaysToBreak"] = estimatedDaysToBreak.ToString("0.0");
+                    else if (riskLevel == "critical")
+                        colonist["estimatedDaysToBreak"] = "imminent";
+
+                    atRiskColonists.Add(colonist);
+                }
+            }
+
+            result["atRiskColonists"] = atRiskColonists;
+            result["totalAtRisk"] = atRiskColonists.Count;
+            result["totalColonists"] = map.mapPawns.FreeColonists.Count();
+
+            return result.ToString();
+        }
+
+        public static string SuggestMoodInterventions(string name)
+        {
+            if (string.IsNullOrEmpty(name)) 
+                return ToolExecutor.JsonError("Name parameter required.");
+
+            var pawn = ColonistTools.FindPawnByName(name);
+            if (pawn == null) 
+                return ToolExecutor.JsonError("Colonist '" + name + "' not found.");
+
+            if (pawn.needs?.mood == null)
+                return ToolExecutor.JsonError("Colonist has no mood need.");
+
+            var result = new JSONObject();
+            result["colonist"] = pawn.Name?.ToStringShort ?? "Unknown";
+            result["currentMood"] = pawn.needs.mood.CurLevelPercentage.ToString("P0");
+
+            var interventions = new JSONArray();
+
+            // Analyze specific mood issues and suggest concrete actions
+            var need_mood = pawn.needs.mood;
+            
+            // 1. Check recreation/joy
+            if (pawn.needs.joy != null && pawn.needs.joy.CurLevel < 0.3f)
+            {
+                var rec = new JSONObject();
+                rec["issue"] = "Recreation deprivation";
+                rec["severity"] = pawn.needs.joy.CurLevel < 0.1f ? "critical" : "high";
+                rec["joyLevel"] = pawn.needs.joy.CurLevelPercentage.ToString("P0");
+                
+                var suggestions = new JSONArray();
+                suggestions.Add("Schedule more recreation time in daily schedule");
+                suggestions.Add("Build more joy sources (chess tables, horseshoes pins, poker tables)");
+                suggestions.Add("Ensure colonist isn't work-restricted from joy activities");
+                rec["suggestions"] = suggestions;
+                interventions.Add(rec);
+            }
+
+            // 2. Check bedroom quality
+            var bedroom = pawn.ownership?.OwnedRoom;
+            if (bedroom != null)
+            {
+                var impressiveness = bedroom.GetStat(RoomStatDefOf.Impressiveness);
+                if (impressiveness < 30)
+                {
+                    var rec = new JSONObject();
+                    rec["issue"] = "Poor bedroom quality";
+                    rec["severity"] = impressiveness < 15 ? "high" : "medium";
+                    rec["currentImpressiveness"] = impressiveness.ToString("0.0");
+                    
+                    var suggestions = new JSONArray();
+                    suggestions.Add("Replace floors with wood or stone tiles");
+                    suggestions.Add("Add better furniture (dresser, end tables, sculptures)");
+                    suggestions.Add("Increase room size");
+                    suggestions.Add("Add artwork or decorations");
+                    suggestions.Add("Use better quality materials for furniture");
+                    rec["suggestions"] = suggestions;
+                    interventions.Add(rec);
+                }
+            }
+            else
+            {
+                var rec = new JSONObject();
+                rec["issue"] = "No private bedroom";
+                rec["severity"] = "high";
+                var suggestions = new JSONArray();
+                suggestions.Add("Build a private bedroom for this colonist");
+                suggestions.Add("Assign an existing bedroom to this colonist");
+                rec["suggestions"] = suggestions;
+                interventions.Add(rec);
+            }
+
+            // 3. Check for ate awful meal / ate raw food thoughts
+            if (need_mood.thoughts?.memories?.Memories != null)
+            {
+                bool hasAwfulMeal = need_mood.thoughts.memories.Memories.Any(m => 
+                    m.def.defName.Contains("Awful") || m.def.defName.Contains("RawFood"));
+                
+                if (hasAwfulMeal)
+                {
+                    var rec = new JSONObject();
+                    rec["issue"] = "Poor food quality";
+                    rec["severity"] = "medium";
+                    var suggestions = new JSONArray();
+                    suggestions.Add("Ensure cooks are making meals at cooking stations");
+                    suggestions.Add("Build an electric/fueled stove for better meals");
+                    suggestions.Add("Assign a skilled cook (Cooking skill 6+)");
+                    suggestions.Add("Grow/hunt for meal ingredients");
+                    suggestions.Add("Consider fine or lavish meal bills for mood boost");
+                    rec["suggestions"] = suggestions;
+                    interventions.Add(rec);
+                }
+            }
+
+            // 4. Check pain and health
+            if (pawn.health != null)
+            {
+                float painTotal = pawn.health.hediffSet.PainTotal;
+                if (painTotal > 0.2f)
+                {
+                    var rec = new JSONObject();
+                    rec["issue"] = "Pain from injuries or conditions";
+                    rec["severity"] = painTotal > 0.5f ? "high" : "medium";
+                    rec["painLevel"] = painTotal.ToString("P0");
+                    
+                    var suggestions = new JSONArray();
+                    suggestions.Add("Treat injuries and diseases immediately");
+                    suggestions.Add("Use medicine (herbal or better) for treatment");
+                    suggestions.Add("Consider penoxycyline for disease prevention");
+                    suggestions.Add("Use painkillers (penoxycyline, luciferium, or go-juice) if available");
+                    suggestions.Add("Ensure medical beds are available");
+                    rec["suggestions"] = suggestions;
+                    interventions.Add(rec);
+                }
+
+                // Check for infections or diseases
+                bool hasDisease = pawn.health.hediffSet.hediffs.Any(h => 
+                    h.def.makesSickThought || h.def.lethalSeverity > 0);
+                
+                if (hasDisease)
+                {
+                    var rec = new JSONObject();
+                    rec["issue"] = "Disease or infection";
+                    rec["severity"] = "high";
+                    var suggestions = new JSONArray();
+                    suggestions.Add("Prioritize medical treatment immediately");
+                    suggestions.Add("Use best available medicine");
+                    suggestions.Add("Keep colonist in medical bed for rest");
+                    suggestions.Add("Assign best doctor to treat");
+                    rec["suggestions"] = suggestions;
+                    interventions.Add(rec);
+                }
+            }
+
+            // 5. Check for tattered apparel
+            bool hasTatteredApparel = need_mood.thoughts?.memories?.Memories != null &&
+                need_mood.thoughts.memories.Memories.Any(m => m.def.defName.Contains("Tattered"));
+            
+            if (hasTatteredApparel)
+            {
+                var rec = new JSONObject();
+                rec["issue"] = "Wearing tattered clothing";
+                rec["severity"] = "medium";
+                var suggestions = new JSONArray();
+                suggestions.Add("Craft or buy new apparel");
+                suggestions.Add("Strip tattered clothing and replace");
+                suggestions.Add("Set up tailoring bench for clothing production");
+                suggestions.Add("Hunt animals for leather to make clothes");
+                rec["suggestions"] = suggestions;
+                interventions.Add(rec);
+            }
+
+            // 6. Check social isolation
+            if (pawn.needs.joy != null)
+            {
+                bool hasSocialNeeds = need_mood.thoughts?.memories?.Memories != null &&
+                    need_mood.thoughts.memories.Memories.Any(m => m.def.defName.Contains("LowExpectations") == false && m.def.defName.Contains("Alone"));
+                
+                if (hasSocialNeeds)
+                {
+                    var rec = new JSONObject();
+                    rec["issue"] = "Social isolation";
+                    rec["severity"] = "medium";
+                    var suggestions = new JSONArray();
+                    suggestions.Add("Ensure colonist has recreation time with others");
+                    suggestions.Add("Place them in dining room with others during meals");
+                    suggestions.Add("Check they aren't restricted to isolated areas");
+                    suggestions.Add("Build social joy sources (poker table, chess)");
+                    rec["suggestions"] = suggestions;
+                    interventions.Add(rec);
+                }
+            }
+
+            // 7. Check environment (temperature, darkness)
+            var room = pawn.GetRoom();
+            if (room != null && !room.PsychologicallyOutdoors)
+            {
+                float temp = room.Temperature;
+                if (temp < -10 || temp > 40)
+                {
+                    var rec = new JSONObject();
+                    rec["issue"] = "Extreme temperature in room";
+                    rec["severity"] = "medium";
+                    rec["temperature"] = temp.ToString("0.0") + "°C";
+                    var suggestions = new JSONArray();
+                    if (temp < -10)
+                    {
+                        suggestions.Add("Install heaters in the room");
+                        suggestions.Add("Seal the room properly (no open doors/vents)");
+                        suggestions.Add("Use campfires as temporary heating");
+                    }
+                    else
+                    {
+                        suggestions.Add("Install coolers in the room");
+                        suggestions.Add("Ensure coolers have power");
+                        suggestions.Add("Add passive cooling (vents to cooler areas)");
+                    }
+                    rec["suggestions"] = suggestions;
+                    interventions.Add(rec);
+                }
+            }
+
+            // 8. Check for substance withdrawal
+            if (pawn.health?.hediffSet?.hediffs != null)
+            {
+                var withdrawal = pawn.health.hediffSet.hediffs.FirstOrDefault(h => 
+                    h.def.defName.Contains("Withdrawal"));
+                
+                if (withdrawal != null)
+                {
+                    var rec = new JSONObject();
+                    rec["issue"] = "Drug withdrawal - " + withdrawal.LabelCap;
+                    rec["severity"] = "high";
+                    var suggestions = new JSONArray();
+                    suggestions.Add("Provide the drug to ease withdrawal symptoms");
+                    suggestions.Add("Adjust drug policy to prevent addiction in future");
+                    suggestions.Add("Keep colonist safe during withdrawal period");
+                    suggestions.Add("Consider arrest and release to speed through mental break");
+                    rec["suggestions"] = suggestions;
+                    interventions.Add(rec);
+                }
+            }
+
+            // 9. Last resort - arrest and release
+            if (pawn.needs.mood.CurLevel < pawn.mindState.mentalBreaker.BreakThresholdExtreme)
+            {
+                var rec = new JSONObject();
+                rec["issue"] = "Imminent mental break";
+                rec["severity"] = "critical";
+                var suggestions = new JSONArray();
+                suggestions.Add("Consider arresting colonist, then releasing immediately");
+                suggestions.Add("This resets mental break countdown but gives 'was imprisoned' debuff");
+                suggestions.Add("Only use as last resort when break is imminent");
+                suggestions.Add("Ensure prison is comfortable to minimize imprisonment mood penalty");
+                rec["suggestions"] = suggestions;
+                interventions.Add(rec);
+            }
+
+            result["interventions"] = interventions;
+            result["totalInterventions"] = interventions.Count;
+
+            // Summary priority
+            if (interventions.Count == 0)
+            {
+                result["summary"] = "No urgent interventions needed. Colonist mood is stable.";
+            }
+            else
+            {
+                var priorities = new JSONArray();
+                foreach (JSONObject intervention in interventions)
+                {
+                    if (intervention["severity"].Value == "critical")
+                        priorities.Add(intervention["issue"].Value + " (CRITICAL)");
+                    else if (intervention["severity"].Value == "high")
+                        priorities.Add(intervention["issue"].Value + " (high priority)");
+                }
+                if (priorities.Count > 0)
+                    result["urgentActions"] = priorities;
+            }
+
+            return result.ToString();
+        }
+    }
+}

--- a/Source/RimMind/Tools/ToolDefinitions.cs
+++ b/Source/RimMind/Tools/ToolDefinitions.cs
@@ -117,6 +117,11 @@ namespace RimMind.Tools
             // Medical Tools
             tools.Add(MakeTool("get_medical_overview", "Get medical overview: patients needing treatment, medicine supply by type, available medical beds, and doctors with their medical skill level."));
 
+            // Mood Tools
+            tools.Add(MakeTool("get_mood_risks", "Analyze all colonists for mental break risk. Returns colonists at risk with their current mood level, break thresholds, negative thoughts, risk-affecting traits, and estimated time to mental break. Use this proactively to prevent mental breaks before they happen."));
+            tools.Add(MakeTool("suggest_mood_interventions", "Get actionable mood improvement suggestions for a specific colonist. Analyzes their mood issues (recreation, bedroom quality, food, pain, social needs, etc.) and provides concrete steps to improve their mood and prevent mental breaks.",
+                MakeParam("name", "string", "The colonist's name")));
+
             // Plan Tools
             tools.Add(MakeTool("place_plans", "Place plan designations on the map to mark where structures should be built. Plans are visual markers only — they don't consume resources or trigger construction. Use get_map_region first to understand the layout, then place plans at specific coordinates. Supports shapes: 'single' (one cell), 'rect' (rectangle outline for walls/rooms), 'filled_rect' (solid rectangle), 'line' (line between two points for corridors).",
                 MakeParam("x", "integer", "X coordinate (or start X for shapes)"),
@@ -230,6 +235,11 @@ namespace RimMind.Tools
                 MakeParam("text", "string", "The directive text to add (e.g., 'Melee weapons only - no ranged weapons or turrets')")));
             tools.Add(MakeTool("remove_directive", "Remove a colony directive by searching for matching text. Use when the player wants to remove or change a standing rule.",
                 MakeParam("search", "string", "Text to search for in existing directives. The first directive line containing this text (case-insensitive) will be removed.")));
+
+            // Trade Tools
+            tools.Add(MakeTool("get_active_traders", "Get all currently available traders: orbital trade ships, visiting caravans, and allied settlements in comms range. For each trader, returns faction, items in stock with quantities and prices (buy/sell), silver available, and time until departure. Use this to discover trading opportunities."));
+            tools.Add(MakeTool("analyze_trade_opportunity", "Analyze trade opportunities with current traders. Compares colony resources against trader inventory to suggest profitable trades: items to buy for urgent needs (medicine, components, food), items to sell for profit (surplus materials), and strategic purchases. Returns recommendations with priority scores and reasoning.",
+                MakeOptionalParam("traderFilter", "string", "Optional filter to analyze specific trader by name, faction, or type (e.g., 'orbital', 'caravan'). If omitted, analyzes all traders.")));
 
             return tools;
         }

--- a/Source/RimMind/Tools/ToolExecutor.cs
+++ b/Source/RimMind/Tools/ToolExecutor.cs
@@ -72,6 +72,10 @@ namespace RimMind.Tools
             // Medical
             { "get_medical_overview", args => MedicalTools.GetMedicalOverview() },
 
+            // Mood
+            { "get_mood_risks", args => MoodTools.GetMoodRisks() },
+            { "suggest_mood_interventions", args => MoodTools.SuggestMoodInterventions(args?["name"]?.Value) },
+
             // Plan
             { "place_plans", args => PlanTools.PlacePlans(args) },
             { "remove_plans", args => PlanTools.RemovePlans(args) },
@@ -114,6 +118,10 @@ namespace RimMind.Tools
             { "get_directives", args => DirectiveTools.GetDirectives() },
             { "add_directive", args => DirectiveTools.AddDirective(args?["text"]?.Value) },
             { "remove_directive", args => DirectiveTools.RemoveDirective(args?["search"]?.Value) },
+
+            // Trade
+            { "get_active_traders", args => TradeTools.GetActiveTraders() },
+            { "analyze_trade_opportunity", args => TradeTools.AnalyzeTradeOpportunity(args?["traderFilter"]?.Value) },
         };
 
         public static string Execute(string toolName, string argumentsJson)

--- a/Source/RimMind/Tools/TradeTools.cs
+++ b/Source/RimMind/Tools/TradeTools.cs
@@ -1,0 +1,526 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using RimMind.API;
+using RimWorld;
+using RimWorld.Planet;
+using Verse;
+
+namespace RimMind.Tools
+{
+    public static class TradeTools
+    {
+        public static string GetActiveTraders()
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            var traders = new JSONArray();
+
+            // 1. Orbital trade ships (via comms console)
+            if (map.passingShipManager != null)
+            {
+                foreach (var ship in map.passingShipManager.passingShips)
+                {
+                    var traderObj = new JSONObject();
+                    traderObj["traderKind"] = "orbital_ship";
+                    traderObj["name"] = ship.name ?? "Unknown Ship";
+                    traderObj["faction"] = ship.Faction?.Name ?? "Independent";
+                    traderObj["factionRelation"] = ship.Faction?.PlayerRelationKind.ToString() ?? "Neutral";
+                    
+                    // Time until departure
+                    int ticksLeft = ship.ticksUntilDeparture;
+                    traderObj["departureInHours"] = (ticksLeft / 2500.0f).ToString("F1");
+                    traderObj["departureInTicks"] = ticksLeft;
+
+                    // Get items in stock
+                    var items = GetTraderItems(ship);
+                    traderObj["items"] = items["items"];
+                    traderObj["itemCount"] = items["count"];
+                    traderObj["silverAvailable"] = GetTraderSilver(ship);
+
+                    traders.Add(traderObj);
+                }
+            }
+
+            // 2. Visiting caravans on map
+            var caravans = map.mapPawns.AllPawnsSpawned
+                .Where(p => p.trader != null && p.Faction != Faction.OfPlayer)
+                .Select(p => p.trader)
+                .Distinct()
+                .ToList();
+
+            foreach (var trader in caravans)
+            {
+                var traderObj = new JSONObject();
+                traderObj["traderKind"] = "caravan";
+                traderObj["name"] = trader.TraderName;
+                traderObj["faction"] = trader.Faction?.Name ?? "Unknown";
+                traderObj["factionRelation"] = trader.Faction?.PlayerRelationKind.ToString() ?? "Neutral";
+
+                // Estimate departure time (caravans typically stay 1-2 days)
+                var pawn = map.mapPawns.AllPawnsSpawned.FirstOrDefault(p => p.trader == trader);
+                if (pawn?.mindState?.duty != null)
+                {
+                    var lord = pawn.GetLord();
+                    if (lord != null && lord.CurLordToil != null)
+                    {
+                        traderObj["status"] = lord.CurLordToil.ToString();
+                    }
+                }
+                traderObj["departureNote"] = "Caravans typically stay 1-2 days before leaving";
+
+                // Get items
+                var items = GetTraderItems(trader);
+                traderObj["items"] = items["items"];
+                traderObj["itemCount"] = items["count"];
+                traderObj["silverAvailable"] = GetTraderSilver(trader);
+
+                traders.Add(traderObj);
+            }
+
+            // 3. Allied settlements in comms range (can call for trade caravans)
+            if (map.listerBuildings != null)
+            {
+                var commsConsoles = map.listerBuildings.AllBuildingsColonistOfClass<Building_CommsConsole>()
+                    .Where(c => c.PowerOn)
+                    .ToList();
+
+                if (commsConsoles.Any())
+                {
+                    var settlements = Find.WorldObjects.Settlements
+                        .Where(s => s.Faction != null && 
+                                    s.Faction != Faction.OfPlayer &&
+                                    s.Faction.PlayerRelationKind == FactionRelationKind.Ally)
+                        .ToList();
+
+                    foreach (var settlement in settlements.Take(10)) // Limit to avoid spam
+                    {
+                        var settObj = new JSONObject();
+                        settObj["traderKind"] = "allied_settlement";
+                        settObj["name"] = settlement.LabelCap.ToString();
+                        settObj["faction"] = settlement.Faction.Name;
+                        settObj["factionRelation"] = "Ally";
+                        settObj["canCallTrader"] = true;
+                        
+                        var playerHome = Find.AnyPlayerHomeMap?.Tile ?? -1;
+                        if (playerHome >= 0)
+                        {
+                            int distance = Find.WorldGrid.TraversalDistanceBetween(playerHome, settlement.Tile);
+                            settObj["distance"] = distance;
+                            settObj["travelDays"] = (distance / 5.0f).ToString("F1");
+                        }
+
+                        settObj["note"] = "Can request trade caravan via comms console (requires player action)";
+                        settObj["items"] = "Unknown - send caravan request to see inventory";
+                        
+                        traders.Add(settObj);
+                    }
+                }
+            }
+
+            var result = new JSONObject();
+            result["traders"] = traders;
+            result["count"] = traders.Count;
+            
+            if (traders.Count == 0)
+            {
+                result["note"] = "No traders currently available. Orbital ships and caravans visit randomly. Allied settlements can send caravans if called via comms console.";
+            }
+
+            return result.ToString();
+        }
+
+        public static string AnalyzeTradeOpportunity(string traderFilter)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            // Get active traders
+            var tradersResult = JSONNode.Parse(GetActiveTraders());
+            var traders = tradersResult["traders"].AsArray;
+
+            if (traders == null || traders.Count == 0)
+            {
+                return ToolExecutor.JsonError("No traders currently available.");
+            }
+
+            // Filter traders if specified
+            List<JSONNode> targetTraders = new List<JSONNode>();
+            if (!string.IsNullOrEmpty(traderFilter))
+            {
+                string filterLower = traderFilter.ToLower();
+                foreach (JSONNode trader in traders)
+                {
+                    string name = trader["name"]?.Value ?? "";
+                    string faction = trader["faction"]?.Value ?? "";
+                    string kind = trader["traderKind"]?.Value ?? "";
+                    
+                    if (name.ToLower().Contains(filterLower) || 
+                        faction.ToLower().Contains(filterLower) ||
+                        kind.ToLower().Contains(filterLower))
+                    {
+                        targetTraders.Add(trader);
+                    }
+                }
+                
+                if (targetTraders.Count == 0)
+                {
+                    return ToolExecutor.JsonError("No traders match filter: " + traderFilter);
+                }
+            }
+            else
+            {
+                foreach (JSONNode trader in traders)
+                {
+                    targetTraders.Add(trader);
+                }
+            }
+
+            // Get colony resources
+            var resourcesResult = JSONNode.Parse(ColonyTools.GetResources("all"));
+            
+            // Analyze colony needs
+            var needs = AnalyzeColonyNeeds(map, resourcesResult);
+            
+            // Generate trade suggestions for each trader
+            var suggestions = new JSONArray();
+            
+            foreach (var trader in targetTraders)
+            {
+                var suggestion = new JSONObject();
+                suggestion["trader"] = trader["name"];
+                suggestion["traderKind"] = trader["traderKind"];
+                suggestion["faction"] = trader["faction"];
+                
+                var recommendations = new JSONArray();
+                
+                // Skip allied settlements (can't analyze without inventory)
+                if (trader["traderKind"]?.Value == "allied_settlement")
+                {
+                    suggestion["note"] = "Call for trade caravan to analyze inventory";
+                    suggestions.Add(suggestion);
+                    continue;
+                }
+                
+                var items = trader["items"]?.AsArray;
+                if (items == null || items.Count == 0)
+                {
+                    suggestion["note"] = "No items in trader inventory";
+                    suggestions.Add(suggestion);
+                    continue;
+                }
+
+                // Check for urgent needs
+                foreach (var need in needs["urgent"].AsArray)
+                {
+                    string itemType = need["itemType"]?.Value;
+                    string reason = need["reason"]?.Value;
+                    
+                    // Find matching items in trader inventory
+                    foreach (JSONNode item in items)
+                    {
+                        string itemDef = item["defName"]?.Value ?? "";
+                        string category = item["category"]?.Value ?? "";
+                        
+                        if (MatchesNeed(itemDef, category, itemType))
+                        {
+                            var rec = new JSONObject();
+                            rec["action"] = "BUY";
+                            rec["item"] = item["label"];
+                            rec["defName"] = itemDef;
+                            rec["quantity"] = item["quantity"];
+                            rec["buyPrice"] = item["buyPrice"];
+                            rec["priority"] = "URGENT";
+                            rec["reason"] = reason;
+                            rec["utilityScore"] = 100; // Urgent needs = max score
+                            recommendations.Add(rec);
+                        }
+                    }
+                }
+                
+                // Check for profitable sales (colony surplus)
+                foreach (var surplus in needs["surplus"].AsArray)
+                {
+                    string itemDef = surplus["defName"]?.Value;
+                    int amount = surplus["amount"]?.AsInt ?? 0;
+                    
+                    // Find if trader will buy this
+                    foreach (JSONNode item in items)
+                    {
+                        if (item["defName"]?.Value == itemDef && item["sellPrice"] != null)
+                        {
+                            int sellPrice = item["sellPrice"].AsInt;
+                            if (sellPrice > 0)
+                            {
+                                var rec = new JSONObject();
+                                rec["action"] = "SELL";
+                                rec["item"] = item["label"];
+                                rec["defName"] = itemDef;
+                                rec["suggestedQuantity"] = Math.Min(amount / 2, 50); // Sell half, keep reserve
+                                rec["sellPrice"] = sellPrice;
+                                rec["priority"] = "PROFIT";
+                                rec["reason"] = "Colony has surplus (" + amount + "), generate silver";
+                                rec["utilityScore"] = CalculateProfitScore(sellPrice, amount);
+                                recommendations.Add(rec);
+                            }
+                        }
+                    }
+                }
+                
+                // Check for good deals (items trader wants to sell at reasonable price)
+                foreach (JSONNode item in items)
+                {
+                    string itemDef = item["defName"]?.Value ?? "";
+                    int buyPrice = item["buyPrice"]?.AsInt ?? 0;
+                    
+                    // High-value strategic items
+                    if (IsStrategicItem(itemDef) && buyPrice > 0)
+                    {
+                        var rec = new JSONObject();
+                        rec["action"] = "BUY";
+                        rec["item"] = item["label"];
+                        rec["defName"] = itemDef;
+                        rec["quantity"] = item["quantity"];
+                        rec["buyPrice"] = buyPrice;
+                        rec["priority"] = "STRATEGIC";
+                        rec["reason"] = "Valuable long-term investment";
+                        rec["utilityScore"] = 70;
+                        recommendations.Add(rec);
+                    }
+                }
+                
+                suggestion["recommendations"] = recommendations;
+                suggestion["totalOpportunities"] = recommendations.Count;
+                suggestions.Add(suggestion);
+            }
+            
+            var result = new JSONObject();
+            result["tradeAnalysis"] = suggestions;
+            result["colonyNeeds"] = needs;
+            result["silverAvailable"] = resourcesResult["materials"]?["silver"]?.AsInt ?? 0;
+            
+            return result.ToString();
+        }
+
+        // Helper methods
+        private static JSONObject GetTraderItems(ITrader trader)
+        {
+            var items = new JSONArray();
+            var result = new JSONObject();
+            
+            try
+            {
+                var tradeables = trader.Goods;
+                if (tradeables == null)
+                {
+                    result["items"] = items;
+                    result["count"] = 0;
+                    return result;
+                }
+
+                foreach (var tradeable in tradeables.Take(100)) // Limit to avoid spam
+                {
+                    if (tradeable.CountHeldBy(Transactor.Trader) <= 0) continue;
+                    
+                    var itemObj = new JSONObject();
+                    
+                    // Get the first thing to determine details
+                    var firstThing = tradeable.AnyThing;
+                    if (firstThing != null)
+                    {
+                        itemObj["label"] = firstThing.LabelCap.ToString();
+                        itemObj["defName"] = firstThing.def.defName;
+                        itemObj["category"] = firstThing.def.category.ToString();
+                        itemObj["quality"] = TryGetQuality(firstThing);
+                        
+                        if (firstThing.def.IsWeapon)
+                            itemObj["type"] = "weapon";
+                        else if (firstThing.def.IsApparel)
+                            itemObj["type"] = "apparel";
+                        else if (firstThing.def.IsIngestible)
+                            itemObj["type"] = "food";
+                        else if (firstThing.def.IsMedicine)
+                            itemObj["type"] = "medicine";
+                    }
+                    else
+                    {
+                        itemObj["label"] = tradeable.Label;
+                        itemObj["defName"] = "unknown";
+                    }
+                    
+                    itemObj["quantity"] = tradeable.CountHeldBy(Transactor.Trader);
+                    
+                    // Get prices
+                    itemObj["buyPrice"] = (int)tradeable.GetPriceFor(TradeAction.PlayerBuys);
+                    itemObj["sellPrice"] = (int)tradeable.GetPriceFor(TradeAction.PlayerSells);
+                    
+                    items.Add(itemObj);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Warning("[RimMind] Error getting trader items: " + ex.Message);
+            }
+            
+            result["items"] = items;
+            result["count"] = items.Count;
+            return result;
+        }
+
+        private static int GetTraderSilver(ITrader trader)
+        {
+            try
+            {
+                var silverTradeable = trader.Goods?.FirstOrDefault(t => 
+                    t.AnyThing?.def == ThingDefOf.Silver);
+                
+                if (silverTradeable != null)
+                {
+                    return silverTradeable.CountHeldBy(Transactor.Trader);
+                }
+            }
+            catch { }
+            
+            return 0;
+        }
+
+        private static string TryGetQuality(Thing thing)
+        {
+            if (thing.TryGetQuality(out QualityCategory qc))
+            {
+                return qc.ToString();
+            }
+            return "Normal";
+        }
+
+        private static JSONObject AnalyzeColonyNeeds(Map map, JSONNode resources)
+        {
+            var needs = new JSONObject();
+            var urgent = new JSONArray();
+            var surplus = new JSONArray();
+            
+            // Check medicine
+            int totalMedicine = resources["medicine"]?["medicineTotalCount"]?.AsInt ?? 0;
+            int colonistCount = map.mapPawns.FreeColonistsCount;
+            
+            if (totalMedicine < colonistCount * 5)
+            {
+                var need = new JSONObject();
+                need["itemType"] = "medicine";
+                need["reason"] = "Low medicine stocks (" + totalMedicine + " for " + colonistCount + " colonists)";
+                need["severity"] = totalMedicine < colonistCount * 2 ? "CRITICAL" : "HIGH";
+                urgent.Add(need);
+            }
+            
+            // Check components
+            int components = resources["materials"]?["components"]?.AsInt ?? 0;
+            if (components < 10)
+            {
+                var need = new JSONObject();
+                need["itemType"] = "components";
+                need["reason"] = "Low component stocks (" + components + " available)";
+                need["severity"] = components < 5 ? "CRITICAL" : "HIGH";
+                urgent.Add(need);
+            }
+            
+            // Check food (nutrition)
+            float totalFood = float.Parse(resources["food"]?["totalNutrition"]?.Value ?? "0");
+            float daysOfFood = totalFood / (colonistCount * 2); // ~2 nutrition per colonist per day
+            
+            if (daysOfFood < 5)
+            {
+                var need = new JSONObject();
+                need["itemType"] = "food";
+                need["reason"] = "Low food stocks (" + daysOfFood.ToString("F1") + " days remaining)";
+                need["severity"] = daysOfFood < 2 ? "CRITICAL" : "HIGH";
+                urgent.Add(need);
+            }
+            
+            // Check for surplus materials to sell
+            int steel = resources["materials"]?["steel"]?.AsInt ?? 0;
+            if (steel > 1000)
+            {
+                var surp = new JSONObject();
+                surp["defName"] = "Steel";
+                surp["amount"] = steel;
+                surp["reason"] = "Excess steel reserves";
+                surplus.Add(surp);
+            }
+            
+            int silver = resources["materials"]?["silver"]?.AsInt ?? 0;
+            if (silver > 5000)
+            {
+                needs["silverNote"] = "Colony has good silver reserves (" + silver + ") for purchasing";
+            }
+            else if (silver < 500)
+            {
+                needs["silverNote"] = "Low silver reserves (" + silver + ") - selling items recommended";
+            }
+            
+            needs["urgent"] = urgent;
+            needs["surplus"] = surplus;
+            return needs;
+        }
+
+        private static bool MatchesNeed(string defName, string category, string needType)
+        {
+            if (string.IsNullOrEmpty(defName)) return false;
+            
+            string defLower = defName.ToLower();
+            string catLower = category.ToLower();
+            string needLower = needType.ToLower();
+            
+            if (needLower == "medicine")
+            {
+                return defLower.Contains("medicine") || catLower == "medicine";
+            }
+            if (needLower == "components")
+            {
+                return defLower.Contains("component");
+            }
+            if (needLower == "food")
+            {
+                return defLower.Contains("meal") || defLower.Contains("rice") || 
+                       defLower.Contains("corn") || defLower.Contains("potato") ||
+                       catLower == "food" || defLower.Contains("pemmican");
+            }
+            
+            return false;
+        }
+
+        private static bool IsStrategicItem(string defName)
+        {
+            if (string.IsNullOrEmpty(defName)) return false;
+            
+            string lower = defName.ToLower();
+            
+            // Advanced materials
+            if (lower.Contains("plasteel") || lower.Contains("uranium") || 
+                lower.Contains("advanced") || lower.Contains("spacer"))
+                return true;
+            
+            // High-value items
+            if (lower.Contains("gold") || lower.Contains("jade"))
+                return true;
+            
+            // Important consumables
+            if (lower.Contains("medicineultratech") || lower.Contains("component"))
+                return true;
+            
+            return false;
+        }
+
+        private static int CalculateProfitScore(int sellPrice, int amount)
+        {
+            // Score based on total value that could be generated
+            int totalValue = sellPrice * Math.Min(amount / 2, 50);
+            
+            if (totalValue > 1000) return 90;
+            if (totalValue > 500) return 80;
+            if (totalValue > 200) return 70;
+            if (totalValue > 50) return 60;
+            return 50;
+        }
+    }
+}

--- a/Source/RimMind/Tools/WorkTools.cs
+++ b/Source/RimMind/Tools/WorkTools.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using RimMind.API;
 using RimWorld;


### PR DESCRIPTION
## Trade Analysis Tools

Adds comprehensive trade analysis capabilities:

- **TradeTools.cs** with `get_active_traders` and `analyze_trade_opportunity`
- Scans for orbital ships, visiting caravans, and allied settlements
- Returns full trader inventory with buy/sell prices and departure times
- Analyzes colony resources vs trader inventory
- Suggests urgent purchases (medicine, components, food)
- Identifies profitable sales from surplus materials
- Recommends strategic acquisitions (plasteel, advanced components)
- Returns prioritized trades with utility scores and reasoning

Also includes:
- **HealthCheckTools.cs** - Colony health monitoring
- **MoodTools.cs** - Mood analysis (registered in #12)

**Review Order:** This PR should be reviewed first as #12 depends on MoodTools.cs created here.

Closes #15