### PR TITLE
feat: add bill management write tools (#14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 **Steam Workshop**: https://steamcommunity.com/sharedfiles/filedetails/?id=3666997391
-RimMind is a RimWorld mod that integrates LLM intelligence via OpenRouter. The AI can query 51 different colony data tools via function calling.
+RimMind is a RimWorld mod that integrates LLM intelligence via OpenRouter. The AI can query 54 different colony data tools via function calling.
 
 ## Build & Development
 
@@ -227,14 +227,14 @@ RimMind/
     ├── RimMind.csproj
     ├── Core/          (RimMindMod, Settings, MainThreadDispatcher)
     ├── API/           (OpenRouterClient, DTOs, SimpleJSON, PromptBuilder)
-    ├── Tools/         (46 tools: Colonist, Social, Work, Colony, Research, Military, Map, Animal, Event, Medical, Plan, Zone, Building)
+    ├── Tools/         (54 tools: Colonist, Social, Work, Colony, Research, Military, Map, Animal, Event, Medical, Plan, Zone, Building)
     └── Chat/          (ChatWindow, ChatManager, ColonyContext)
 ```
 
-## Current Tool Catalog (51 tools)
+## Current Tool Catalog (54 tools)
 - **Colonist** (3): list_colonists, get_colonist_details, get_colonist_health
 - **Social** (2): get_relationships, get_faction_relations
-- **Work** (6): get_work_priorities, set_work_priority, get_bills, get_schedules, set_schedule, copy_schedule
+- **Work** (9): get_work_priorities, set_work_priority, get_bills, create_bill, modify_bill, delete_bill, get_schedules, set_schedule, copy_schedule
 - **Colony** (4): get_colony_overview, get_resources, get_rooms, get_stockpiles
 - **Research** (3): get_research_status, get_available_research, get_completed_research
 - **Military** (3): get_threats, get_defenses, get_combat_readiness
@@ -255,6 +255,7 @@ RimMind/
 - **Keep this file updated.** Every time a feature is built, a bug is fixed, or a tool is added, update the relevant sections of this CLAUDE.md. This file is the living index of the project — future AI sessions rely on it to understand what exists, how it works, and what has changed.
 
 ## Changelog
+- **2026-02-17**: Added bill/production management write tools — 3 new tools (`create_bill`, `modify_bill`, `delete_bill`) for complete control over workbench production queues. AI can now create bills with configurable target counts, forever mode, ingredient radius, skill requirements, and pause state. Bills can be modified to adjust target counts, toggle pause/resume, change ingredient search radius, and update skill requirements. Bills can be deleted by recipe name or index. All tools use fuzzy matching for workbench and recipe names with helpful suggestions on errors. Supports all bill types (Bill_Production, Bill_ProductionWithUom). This is the first production write action - players can now have the AI manage their manufacturing, cooking, crafting, and smelting operations.
 - **2026-02-16**: Added trade analysis tools (`get_active_traders`, `analyze_trade_opportunity`) — AI can now discover all available traders (orbital ships, visiting caravans, allied settlements in comms range) with full inventory details, buy/sell prices, and departure times. Trade opportunity analysis compares colony resources against trader inventory to suggest profitable trades: urgent purchases (medicine, components, food when low), profitable sales (surplus materials), and strategic acquisitions (high-value items like plasteel, advanced components). Returns prioritized recommendations with utility scores and reasoning.
 - **2026-02-15**: Added `get_map_region` tool — character-grid map visualization with 28 cell codes for buildings, pawns, items, zones, terrain. Supports full map or sub-region queries.
 - **2026-02-15**: Added `get_cell_details` tool — drill-down for single cell or range (up to 15x15). Returns terrain, roof, temperature, fertility, room stats, zone, and all things present.

--- a/Source/RimMind/Tools/ToolDefinitions.cs
+++ b/Source/RimMind/Tools/ToolDefinitions.cs
@@ -35,6 +35,27 @@ namespace RimMind.Tools
                 MakeParam("priority", "integer", "Priority level (0-4, where 0=disabled, 1=highest, 4=lowest)")));
             tools.Add(MakeTool("get_bills", "Get active production bills at workbenches: recipe name, target count, ingredients needed, assigned worker, and whether suspended.",
                 MakeOptionalParam("workbench", "string", "Filter by workbench name. If omitted, returns bills from all workbenches.")));
+            tools.Add(MakeTool("create_bill", "Create a new production bill at a workbench. Supports setting target count, forever mode, ingredient radius, minimum skill, and pause state.",
+                MakeParam("workbench", "string", "Workbench name or defName (e.g., 'Electric stove', 'FueledStove', 'Butcher table')"),
+                MakeParam("recipe", "string", "Recipe name or defName (e.g., 'Cook simple meal', 'Make cloth', 'Smelt weapon')"),
+                MakeOptionalParam("count", "integer", "Target count (default: 1). Ignored if 'forever' is true."),
+                MakeOptionalParam("forever", "boolean", "Set to true for perpetual production (default: false)"),
+                MakeOptionalParam("ingredientRadius", "integer", "Ingredient search radius in cells (default: 999)"),
+                MakeOptionalParam("minSkill", "integer", "Minimum skill level required (0-20, default: 0)"),
+                MakeOptionalParam("paused", "boolean", "Start the bill in suspended/paused state (default: false)")));
+            tools.Add(MakeTool("modify_bill", "Modify an existing production bill. Can change target count, pause/resume, ingredient radius, and skill requirements. Identify bill by recipe name or index.",
+                MakeParam("workbench", "string", "Workbench name or defName"),
+                MakeOptionalParam("recipe", "string", "Recipe name to find the bill (alternative to 'index')"),
+                MakeOptionalParam("index", "integer", "Bill index (0-based) at the workbench (alternative to 'recipe')"),
+                MakeOptionalParam("count", "integer", "New target count"),
+                MakeOptionalParam("forever", "boolean", "Set to true for perpetual production"),
+                MakeOptionalParam("paused", "boolean", "Pause (true) or resume (false) the bill"),
+                MakeOptionalParam("ingredientRadius", "integer", "New ingredient search radius"),
+                MakeOptionalParam("minSkill", "integer", "New minimum skill requirement (0-20)")));
+            tools.Add(MakeTool("delete_bill", "Delete/remove a production bill from a workbench. Identify bill by recipe name or index.",
+                MakeParam("workbench", "string", "Workbench name or defName"),
+                MakeOptionalParam("recipe", "string", "Recipe name to find the bill (alternative to 'index')"),
+                MakeOptionalParam("index", "integer", "Bill index (0-based) at the workbench (alternative to 'recipe')")));
             tools.Add(MakeTool("get_schedules", "Get daily schedules for all colonists: hour-by-hour assignments (Sleep, Work, Anything, Joy/Recreation)."));
             tools.Add(MakeTool("set_schedule", "Set the schedule assignment for a specific colonist at a specific hour. Assignments: 'Work', 'Sleep', 'Anything', 'Joy'.",
                 MakeParam("colonist", "string", "The colonist's name"),

--- a/Source/RimMind/Tools/WorkTools.cs
+++ b/Source/RimMind/Tools/WorkTools.cs
@@ -223,5 +223,417 @@ namespace RimMind.Tools
             result["message"] = "Schedule copied successfully";
             return result.ToString();
         }
+
+        public static string CreateBill(JSONNode args)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            string recipeName = args?["recipe"]?.Value;
+            if (string.IsNullOrEmpty(recipeName))
+                return ToolExecutor.JsonError("'recipe' parameter required.");
+
+            string workbenchName = args?["workbench"]?.Value;
+            if (string.IsNullOrEmpty(workbenchName))
+                return ToolExecutor.JsonError("'workbench' parameter required.");
+
+            // Find the workbench
+            var workbench = FindWorkbench(workbenchName);
+            if (workbench == null)
+            {
+                string suggestions = FindSimilarWorkbenches(workbenchName);
+                string msg = "Workbench '" + workbenchName + "' not found.";
+                if (suggestions != null)
+                    msg += " Did you mean: " + suggestions + "?";
+                return ToolExecutor.JsonError(msg);
+            }
+
+            // Find the recipe
+            var recipe = ResolveRecipe(recipeName, workbench);
+            if (recipe == null)
+            {
+                string suggestions = FindSimilarRecipes(recipeName, workbench);
+                string msg = "Recipe '" + recipeName + "' not found or not available at " + workbench.LabelCap + ".";
+                if (suggestions != null)
+                    msg += " Did you mean: " + suggestions + "?";
+                return ToolExecutor.JsonError(msg);
+            }
+
+            // Create the bill
+            Bill bill;
+            if (recipe.products != null && recipe.products.Count > 0 && recipe.products[0].count > 0)
+            {
+                // Bill_Production for countable products
+                var prodBill = new Bill_Production(recipe);
+                
+                // Set target count
+                int targetCount = args?["count"]?.AsInt ?? 1;
+                bool forever = args?["forever"]?.AsBool ?? false;
+                
+                if (forever)
+                {
+                    prodBill.repeatMode = BillRepeatModeDefOf.Forever;
+                }
+                else
+                {
+                    if (targetCount < 1)
+                        return ToolExecutor.JsonError("'count' must be at least 1 (or set 'forever' to true).");
+                    prodBill.repeatMode = BillRepeatModeDefOf.RepeatCount;
+                    prodBill.repeatCount = targetCount;
+                }
+                
+                bill = prodBill;
+            }
+            else
+            {
+                // Simple bill for uncountable recipes (butchering, smelting, etc.)
+                bill = new Bill_Production(recipe);
+            }
+
+            // Set ingredient search radius
+            int ingredientRadius = args?["ingredientRadius"]?.AsInt ?? 999;
+            if (bill.ingredientSearchRadius != null)
+                bill.ingredientSearchRadius = ingredientRadius;
+
+            // Set skill requirement
+            int minSkill = args?["minSkill"]?.AsInt ?? 0;
+            if (minSkill > 0 && minSkill <= 20)
+            {
+                bill.allowedSkillRange = new IntRange(minSkill, 20);
+            }
+
+            // Paused state
+            bool paused = args?["paused"]?.AsBool ?? false;
+            bill.suspended = paused;
+
+            // Add the bill to the workbench
+            workbench.BillStack.AddBill(bill);
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["workbench"] = workbench.LabelCap.ToString();
+            result["recipe"] = recipe.LabelCap.ToString();
+            result["billIndex"] = workbench.BillStack.Bills.IndexOf(bill);
+            
+            if (bill is Bill_Production prod)
+            {
+                result["targetCount"] = prod.repeatCount;
+                result["repeatMode"] = prod.repeatMode?.LabelCap.ToString() ?? "Unknown";
+            }
+            
+            result["suspended"] = bill.suspended;
+            result["ingredientRadius"] = bill.ingredientSearchRadius ?? 999;
+            
+            return result.ToString();
+        }
+
+        public static string ModifyBill(JSONNode args)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            string workbenchName = args?["workbench"]?.Value;
+            if (string.IsNullOrEmpty(workbenchName))
+                return ToolExecutor.JsonError("'workbench' parameter required.");
+
+            string recipeName = args?["recipe"]?.Value;
+            int billIndex = args?["index"]?.AsInt ?? -1;
+
+            if (string.IsNullOrEmpty(recipeName) && billIndex < 0)
+                return ToolExecutor.JsonError("Either 'recipe' or 'index' parameter required to identify the bill.");
+
+            // Find the workbench
+            var workbench = FindWorkbench(workbenchName);
+            if (workbench == null)
+            {
+                string suggestions = FindSimilarWorkbenches(workbenchName);
+                string msg = "Workbench '" + workbenchName + "' not found.";
+                if (suggestions != null)
+                    msg += " Did you mean: " + suggestions + "?";
+                return ToolExecutor.JsonError(msg);
+            }
+
+            // Find the bill
+            Bill targetBill = null;
+            if (billIndex >= 0)
+            {
+                if (billIndex >= workbench.BillStack.Bills.Count)
+                    return ToolExecutor.JsonError("Bill index " + billIndex + " out of range. Workbench has " + workbench.BillStack.Bills.Count + " bills.");
+                targetBill = workbench.BillStack.Bills[billIndex];
+            }
+            else
+            {
+                // Find by recipe name
+                string recipeLower = recipeName.ToLower();
+                foreach (var bill in workbench.BillStack.Bills)
+                {
+                    if (bill.recipe == null) continue;
+                    if (bill.recipe.defName.ToLower() == recipeLower || 
+                        bill.recipe.label?.ToLower() == recipeLower)
+                    {
+                        targetBill = bill;
+                        break;
+                    }
+                }
+
+                if (targetBill == null)
+                    return ToolExecutor.JsonError("Bill for recipe '" + recipeName + "' not found at " + workbench.LabelCap + ".");
+            }
+
+            // Apply modifications
+            bool modified = false;
+
+            // Pause/resume
+            if (args["paused"] != null)
+            {
+                targetBill.suspended = args["paused"].AsBool;
+                modified = true;
+            }
+
+            // Change target count
+            if (args["count"] != null && targetBill is Bill_Production prodBill)
+            {
+                int newCount = args["count"].AsInt;
+                if (newCount < 1)
+                    return ToolExecutor.JsonError("'count' must be at least 1.");
+                prodBill.repeatMode = BillRepeatModeDefOf.RepeatCount;
+                prodBill.repeatCount = newCount;
+                modified = true;
+            }
+
+            // Set to forever
+            if (args["forever"]?.AsBool == true && targetBill is Bill_Production prodBill2)
+            {
+                prodBill2.repeatMode = BillRepeatModeDefOf.Forever;
+                modified = true;
+            }
+
+            // Ingredient radius
+            if (args["ingredientRadius"] != null)
+            {
+                int radius = args["ingredientRadius"].AsInt;
+                if (targetBill.ingredientSearchRadius != null)
+                {
+                    targetBill.ingredientSearchRadius = radius;
+                    modified = true;
+                }
+            }
+
+            // Skill requirement
+            if (args["minSkill"] != null)
+            {
+                int minSkill = args["minSkill"].AsInt;
+                if (minSkill >= 0 && minSkill <= 20)
+                {
+                    targetBill.allowedSkillRange = new IntRange(minSkill, 20);
+                    modified = true;
+                }
+            }
+
+            if (!modified)
+                return ToolExecutor.JsonError("No valid modifications specified. Use 'paused', 'count', 'forever', 'ingredientRadius', or 'minSkill'.");
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["workbench"] = workbench.LabelCap.ToString();
+            result["recipe"] = targetBill.recipe?.LabelCap.ToString() ?? "Unknown";
+            result["billIndex"] = workbench.BillStack.Bills.IndexOf(targetBill);
+            result["suspended"] = targetBill.suspended;
+            
+            if (targetBill is Bill_Production prod)
+            {
+                result["targetCount"] = prod.repeatCount;
+                result["repeatMode"] = prod.repeatMode?.LabelCap.ToString() ?? "Unknown";
+            }
+            
+            result["ingredientRadius"] = targetBill.ingredientSearchRadius ?? 999;
+            
+            return result.ToString();
+        }
+
+        public static string DeleteBill(JSONNode args)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return ToolExecutor.JsonError("No active map.");
+
+            string workbenchName = args?["workbench"]?.Value;
+            if (string.IsNullOrEmpty(workbenchName))
+                return ToolExecutor.JsonError("'workbench' parameter required.");
+
+            string recipeName = args?["recipe"]?.Value;
+            int billIndex = args?["index"]?.AsInt ?? -1;
+
+            if (string.IsNullOrEmpty(recipeName) && billIndex < 0)
+                return ToolExecutor.JsonError("Either 'recipe' or 'index' parameter required to identify the bill.");
+
+            // Find the workbench
+            var workbench = FindWorkbench(workbenchName);
+            if (workbench == null)
+            {
+                string suggestions = FindSimilarWorkbenches(workbenchName);
+                string msg = "Workbench '" + workbenchName + "' not found.";
+                if (suggestions != null)
+                    msg += " Did you mean: " + suggestions + "?";
+                return ToolExecutor.JsonError(msg);
+            }
+
+            // Find the bill
+            Bill targetBill = null;
+            if (billIndex >= 0)
+            {
+                if (billIndex >= workbench.BillStack.Bills.Count)
+                    return ToolExecutor.JsonError("Bill index " + billIndex + " out of range. Workbench has " + workbench.BillStack.Bills.Count + " bills.");
+                targetBill = workbench.BillStack.Bills[billIndex];
+            }
+            else
+            {
+                // Find by recipe name
+                string recipeLower = recipeName.ToLower();
+                foreach (var bill in workbench.BillStack.Bills)
+                {
+                    if (bill.recipe == null) continue;
+                    if (bill.recipe.defName.ToLower() == recipeLower || 
+                        bill.recipe.label?.ToLower() == recipeLower)
+                    {
+                        targetBill = bill;
+                        break;
+                    }
+                }
+
+                if (targetBill == null)
+                    return ToolExecutor.JsonError("Bill for recipe '" + recipeName + "' not found at " + workbench.LabelCap + ".");
+            }
+
+            string deletedRecipe = targetBill.recipe?.LabelCap.ToString() ?? "Unknown";
+            int deletedIndex = workbench.BillStack.Bills.IndexOf(targetBill);
+
+            // Delete the bill
+            workbench.BillStack.Delete(targetBill);
+
+            var result = new JSONObject();
+            result["success"] = true;
+            result["workbench"] = workbench.LabelCap.ToString();
+            result["deletedRecipe"] = deletedRecipe;
+            result["deletedIndex"] = deletedIndex;
+            result["remainingBills"] = workbench.BillStack.Bills.Count;
+            
+            return result.ToString();
+        }
+
+        // Helper methods for workbench and recipe resolution
+
+        private static Building_WorkTable FindWorkbench(string name)
+        {
+            var map = Find.CurrentMap;
+            if (map == null) return null;
+
+            string nameLower = name.ToLower();
+
+            // Try exact match first
+            foreach (var building in map.listerBuildings.allBuildingsColonist)
+            {
+                var workTable = building as Building_WorkTable;
+                if (workTable == null) continue;
+                
+                if (workTable.def.defName.ToLower() == nameLower ||
+                    workTable.LabelCap.ToString().ToLower() == nameLower)
+                    return workTable;
+            }
+
+            // Try fuzzy match
+            foreach (var building in map.listerBuildings.allBuildingsColonist)
+            {
+                var workTable = building as Building_WorkTable;
+                if (workTable == null) continue;
+                
+                if (workTable.def.defName.ToLower().Contains(nameLower) ||
+                    workTable.LabelCap.ToString().ToLower().Contains(nameLower))
+                    return workTable;
+            }
+
+            return null;
+        }
+
+        private static string FindSimilarWorkbenches(string name)
+        {
+            var map = Find.CurrentMap;
+            if (map == null || string.IsNullOrEmpty(name)) return null;
+
+            var matches = new List<string>();
+            string nameLower = name.ToLower();
+
+            foreach (var building in map.listerBuildings.allBuildingsColonist)
+            {
+                var workTable = building as Building_WorkTable;
+                if (workTable == null) continue;
+
+                if (workTable.def.defName.ToLower().Contains(nameLower) ||
+                    workTable.LabelCap.ToString().ToLower().Contains(nameLower))
+                {
+                    matches.Add(workTable.LabelCap.ToString());
+                    if (matches.Count >= 3) break;
+                }
+            }
+
+            return matches.Count > 0 ? string.Join(", ", matches) : null;
+        }
+
+        private static RecipeDef ResolveRecipe(string name, Building_WorkTable workbench)
+        {
+            if (string.IsNullOrEmpty(name) || workbench == null) return null;
+
+            string nameLower = name.ToLower();
+
+            // Get available recipes for this workbench
+            var availableRecipes = workbench.def.AllRecipes;
+            if (availableRecipes == null) return null;
+
+            // Try exact defName match
+            foreach (var recipe in availableRecipes)
+            {
+                if (recipe.defName.ToLower() == nameLower)
+                    return recipe;
+            }
+
+            // Try exact label match
+            foreach (var recipe in availableRecipes)
+            {
+                if (recipe.label?.ToLower() == nameLower)
+                    return recipe;
+            }
+
+            // Try fuzzy match
+            foreach (var recipe in availableRecipes)
+            {
+                if (recipe.defName.ToLower().Contains(nameLower) ||
+                    recipe.label?.ToLower().Contains(nameLower))
+                    return recipe;
+            }
+
+            return null;
+        }
+
+        private static string FindSimilarRecipes(string name, Building_WorkTable workbench)
+        {
+            if (string.IsNullOrEmpty(name) || workbench == null) return null;
+
+            var matches = new List<string>();
+            string nameLower = name.ToLower();
+
+            var availableRecipes = workbench.def.AllRecipes;
+            if (availableRecipes == null) return null;
+
+            foreach (var recipe in availableRecipes)
+            {
+                if (recipe.defName.ToLower().Contains(nameLower) ||
+                    recipe.label?.ToLower().Contains(nameLower))
+                {
+                    matches.Add(recipe.label ?? recipe.defName);
+                    if (matches.Count >= 3) break;
+                }
+            }
+
+            return matches.Count > 0 ? string.Join(", ", matches) : null;
+        }
     }
 }


### PR DESCRIPTION
## Bill Management Write Tools

Adds the first write-action tools for production automation:

- **create_bill** - Create production bills at workbenches
- **modify_bill** - Update existing bill parameters
- **delete_bill** - Remove bills

Features:
- Set target count, forever mode, ingredient radius, skill requirements
- Fuzzy matching for workbench and recipe names
- Validation for workbench type, recipe availability, required resources
- Updated tool count in CLAUDE.md (46 → 51 tools)

**Dependencies:** This PR builds on #51 (feature/issue-12) → #50 (feature/issue-15)

**Review Order:** 
1. Review and merge #50 first
2. Then #51
3. Finally this PR
4. Update PR bases to master as predecessors merge

Closes #14