### PR TITLE
chore: change default Claude model to haiku-4-5

### DIFF
--- a/Source/RimMind/Core/RimMindMod.cs
+++ b/Source/RimMind/Core/RimMindMod.cs
@@ -58,7 +58,7 @@ namespace RimMind.Core
 
                 listing.GapLine();
 
-                listing.Label("Model ID (e.g. claude-sonnet-4-5-20250929, claude-opus-4-6):");
+                listing.Label("Model ID (e.g. claude-haiku-4-5, claude-sonnet-4-5, claude-opus-4-6):");
                 Settings.claudeCodeModelId = listing.TextEntry(Settings.claudeCodeModelId);
             }
             else if (Settings.IsAnthropic)
@@ -73,7 +73,7 @@ namespace RimMind.Core
 
                 listing.GapLine();
 
-                listing.Label("Model ID (e.g. claude-sonnet-4-5-20250929, claude-opus-4-6):");
+                listing.Label("Model ID (e.g. claude-haiku-4-5, claude-sonnet-4-5, claude-opus-4-6):");
                 Settings.anthropicModelId = listing.TextEntry(Settings.anthropicModelId);
             }
             else

--- a/Source/RimMind/Core/RimMindSettings.cs
+++ b/Source/RimMind/Core/RimMindSettings.cs
@@ -13,10 +13,10 @@ namespace RimMind.Core
 
         // Anthropic Direct API settings
         public string anthropicToken = "";
-        public string anthropicModelId = "claude-sonnet-4-5-20250929";
+        public string anthropicModelId = "claude-haiku-4-5";
 
         // Claude Code subscription settings
-        public string claudeCodeModelId = "claude-sonnet-4-5-20250929";
+        public string claudeCodeModelId = "claude-haiku-4-5";
 
         // Shared settings
         public float temperature = 0.7f;
@@ -43,8 +43,8 @@ namespace RimMind.Core
             Scribe_Values.Look(ref apiKey, "apiKey", "");
             Scribe_Values.Look(ref modelId, "modelId", "anthropic/claude-sonnet-4-5");
             Scribe_Values.Look(ref anthropicToken, "anthropicToken", "");
-            Scribe_Values.Look(ref anthropicModelId, "anthropicModelId", "claude-sonnet-4-5-20250929");
-            Scribe_Values.Look(ref claudeCodeModelId, "claudeCodeModelId", "claude-sonnet-4-5-20250929");
+            Scribe_Values.Look(ref anthropicModelId, "anthropicModelId", "claude-haiku-4-5");
+            Scribe_Values.Look(ref claudeCodeModelId, "claudeCodeModelId", "claude-haiku-4-5");
             Scribe_Values.Look(ref temperature, "temperature", 0.7f);
             Scribe_Values.Look(ref maxTokens, "maxTokens", 4096);
             Scribe_Values.Look(ref enableChatCompanion, "enableChatCompanion", true);


### PR DESCRIPTION
Changes default model from claude-sonnet-4-5-20250929 to claude-haiku-4-5 as requested by Nicolai.

## Changes Made
- Updated `claudeCodeModelId` default in RimMindSettings.cs
- Updated `anthropicModelId` default in RimMindSettings.cs (for consistency)
- Updated UI example text in RimMindMod.cs to reflect new default

All instances of the old model ID have been replaced. The new default applies to both Claude Code integration and direct Anthropic API usage.