### PR TITLE
feat: Environmental Visibility Tools - Light, Beauty, Pollution, Roof Analysis (#63)

### DIFF
--- a/Source/RimMind/Tools/ToolDefinitions.cs
+++ b/Source/RimMind/Tools/ToolDefinitions.cs
@@ -133,6 +133,36 @@ namespace RimMind.Tools
                 MakeOptionalParam("x2", "integer", "End X of search bounds"),
                 MakeOptionalParam("z2", "integer", "End Z of search bounds")));
 
+            // Environmental Visibility Tools
+            tools.Add(MakeTool("get_light_levels", "Query per-cell light/glow values for illumination analysis. Light levels affect colonist mood and work speed. Returns glow values (0.0-1.0) and descriptions. Single cell or range query (max 15x15). Use to find dark rooms causing mood penalties, verify workspace lighting, or plan lamp placement.",
+                MakeParam("x", "integer", "X coordinate (or start X for range query)"),
+                MakeParam("z", "integer", "Z coordinate (or start Z for range query)"),
+                MakeOptionalParam("x2", "integer", "End X coordinate for range query (max 15x15 area = 225 cells)"),
+                MakeOptionalParam("z2", "integer", "End Z coordinate for range query")));
+            tools.Add(MakeTool("get_light_sources", "List all light sources (lamps, torches) on the map with their position, glow radius, color, and powered status. Use to plan lighting coverage, find unpowered lights, or optimize lamp placement for full coverage.",
+                MakeOptionalParam("x1", "integer", "Start X of bounding box filter (optional)"),
+                MakeOptionalParam("z1", "integer", "Start Z of bounding box filter"),
+                MakeOptionalParam("x2", "integer", "End X of bounding box filter"),
+                MakeOptionalParam("z2", "integer", "End Z of bounding box filter"),
+                MakeOptionalParam("filter", "string", "Filter by defName (e.g., 'StandingLamp', 'Torch')")));
+            tools.Add(MakeTool("get_cell_beauty", "Query per-cell beauty values for environment quality analysis. Beauty affects colonist mood (ugly rooms cause debuffs, beautiful rooms boost mood). Returns beauty values and categories (Hideous/VeryUgly/Ugly/Neutral/Pretty/Beautiful/VeryBeautiful). Single cell or range query (max 15x15). Use to identify ugly areas needing art/plants, verify bedroom beauty for mood, or optimize room impressiveness.",
+                MakeParam("x", "integer", "X coordinate (or start X for range query)"),
+                MakeParam("z", "integer", "Z coordinate (or start Z for range query)"),
+                MakeOptionalParam("x2", "integer", "End X coordinate for range query (max 15x15 area = 225 cells)"),
+                MakeOptionalParam("z2", "integer", "End Z coordinate for range query")));
+            tools.Add(MakeTool("get_pollution", "Query pollution grid for health and environment tracking. Requires Biotech DLC. Pollution affects colonist health and fertility. Returns per-cell pollution status and nearby pollution percentage within 10-cell radius. Single cell or range query (max 15x15). Use to identify polluted areas affecting colonist health, track pollution spread from wastepack atomizers, or verify clean zones for sensitive colonists.",
+                MakeParam("x", "integer", "X coordinate (or start X for range query)"),
+                MakeParam("z", "integer", "Z coordinate (or start Z for range query)"),
+                MakeOptionalParam("x2", "integer", "End X coordinate for range query (max 15x15 area = 225 cells)"),
+                MakeOptionalParam("z2", "integer", "End Z coordinate for range query")));
+            tools.Add(MakeTool("get_roof_status", "Bulk roof analysis for a rectangular region. Returns roof type breakdown (constructed/natural thin/natural thick/none), total roofed vs unroofed cells, and optional breach detection (unroofed cells under overhead mountain). Use to find unroofed areas in bedrooms (temperature control), detect roof breaches in mountain bases (vacuum exposure risk), identify overhead mountain for infestation risk, verify constructed roof coverage, or plan roof construction.",
+                MakeParam("x1", "integer", "Start X coordinate of region"),
+                MakeParam("z1", "integer", "Start Z coordinate of region"),
+                MakeParam("x2", "integer", "End X coordinate of region"),
+                MakeParam("z2", "integer", "End Z coordinate of region"),
+                MakeOptionalParam("roofType", "string", "Filter by roof type: 'none', 'thin', 'thick', 'constructed' (not yet implemented)"),
+                MakeOptionalParam("detectBreaches", "boolean", "Enable breach detection: find unroofed cells adjacent to thick mountain roof (default: false)")));
+
             // Animal Tools
             tools.Add(MakeTool("list_animals", "List all tamed/colony animals: species, name, assigned master, and training completion status."));
             tools.Add(MakeTool("get_animal_details", "Get detailed info about a specific animal: health, training progress for each skill, food requirements, and bonded colonist.",

--- a/Source/RimMind/Tools/ToolExecutor.cs
+++ b/Source/RimMind/Tools/ToolExecutor.cs
@@ -65,6 +65,17 @@ namespace RimMind.Tools
             { "get_cell_details", args => MapTools.GetCellDetails(args) },
             { "get_blueprints", args => MapTools.GetBlueprints(args) },
             { "search_map", args => MapTools.SearchMap(args) },
+            { "get_light_levels", args => MapTools.GetLightLevels(args) },
+            { "get_light_sources", args => MapTools.GetLightSources(args) },
+            { "get_cell_beauty", args => MapTools.GetCellBeauty(args) },
+            { "get_pollution", args => MapTools.GetPollution(args) },
+            { "get_roof_status", args => MapTools.GetRoofStatus(args) },
+
+            // Power Management
+            { "analyze_power_grid", args => PowerTools.AnalyzePowerGrid() },
+            { "check_power_connection", args => PowerTools.CheckPowerConnection(args) },
+            { "suggest_power_route", args => PowerTools.SuggestPowerRoute(args) },
+            { "auto_route_power", args => PowerTools.AutoRoutePower(args) },
 
             // Animals
             { "list_animals", args => AnimalTools.ListAnimals() },


### PR DESCRIPTION
## Overview

Implements 5 new environmental analysis tools requested in issue #63 to give the AI visibility into lighting, beauty, pollution, and roof status.

## Changes

### New Tools

#### 1. `get_light_levels` - Light/Glow Analysis
- Query per-cell glow values (0.0-1.0 scale)
- Single cell or range query (max 15x15)
- Returns glow level, description (pitch black/very dark/dark/dim/well lit/bright), and isDark flag
- Range queries include stats: min/max/avg glow, dark cell count/percentage
- **Use cases:** Find dark rooms causing mood penalties, verify workspace lighting, plan lamp placement

#### 2. `get_light_sources` - Light Source Inventory
- List all light sources (lamps, torches, etc.) on the map
- Returns position, glow radius, color, and powered status for each
- Supports bounds filtering (x1,z1,x2,z2) and defName filter
- **Use cases:** Plan lighting coverage, find unpowered lights, optimize lamp placement

#### 3. `get_cell_beauty` - Beauty Value Analysis
- Query per-cell beauty values with category classification
- Single cell or range query (max 15x15)
- Returns beauty value, description, and category (Hideous/VeryUgly/Ugly/Neutral/Pretty/Beautiful/VeryBeautiful)
- Range queries include stats: min/max/avg beauty, ugly cell count/percentage
- **Use cases:** Identify ugly areas needing art/plants, verify bedroom beauty for mood optimization, optimize room impressiveness

#### 4. `get_pollution` - Pollution Grid Query (Biotech DLC)
- Query pollution grid for health and environment tracking
- Single cell or range query (max 15x15)
- Returns isPolluted flag and nearby pollution percentage (within 10-cell radius)
- Returns friendly error if Biotech DLC not active
- **Use cases:** Identify polluted areas affecting colonist health, track pollution spread, verify clean zones

#### 5. `get_roof_status` - Bulk Roof Analysis
- Analyze rectangular regions for roof coverage
- Returns roof type breakdown (constructed/naturalThin/naturalThick/none)
- Counts roofed vs unroofed cells
- Optional breach detection: finds unroofed cells adjacent to thick mountain roof (potential vacuum exposure)
- **Use cases:** Find unroofed bedrooms (temperature control), detect roof breaches in mountain bases, identify overhead mountain for infestation risk, plan roof construction

## Implementation Details

### Code Structure
- All 5 tools added to `MapTools.cs` (follows existing map analysis patterns)
- Tool definitions added to `ToolDefinitions.cs` with comprehensive descriptions
- Handlers registered in `ToolExecutor.cs`
- Total: 510 lines added across 3 files

### Design Patterns
- Consistent JSON response format (matches existing MapTools)
- Proper error handling: bounds validation, DLC checks, null safety
- Range query support: single cell or up to 15x15 (225 cells) to match `get_cell_details` behavior
- Helper methods for descriptions: `GetLightDescription()`, `GetBeautyDescription()`, `GetBeautyCategory()`

### RimWorld API Usage
- **Light:** `Map.glowGrid.GameGlowAt(cell)` - returns float 0.0-1.0
- **Light sources:** `Building.GetComp<CompGlower>()` with `CompPowerTrader` for power status
- **Beauty:** `BeautyUtility.AverageBeautyPerceptible(cell, map)`
- **Pollution:** `Map.pollutionGrid.IsPolluted(cell)`, `GetTotalPercentWithinRadius()`
- **Roof:** `Map.roofGrid.RoofAt(cell)`, breach detection via `GenAdj.CellsAdjacent8Way`

## Testing Recommendations

### Light Tools
- Query dark storage room vs well-lit workshop
- Find all lamps, verify powered status
- Identify bedrooms needing better lighting

### Beauty Tools
- Compare ugly prison vs beautiful noble bedroom
- Find areas with beauty < -5 (causing mood debuffs)
- Verify bedroom beauty levels for mood optimization

### Pollution (Biotech)
- Test with/without Biotech active (should error gracefully)
- Track pollution spread from wastepack atomizers
- Identify polluted areas affecting colonist health

### Roof Analysis
- Mountain base: verify breach detection finds unroofed cells under overhead mountain
- Desert map: check constructed roof coverage
- Find unroofed bedrooms for temperature control

## User Value

These tools address the gap identified in #63: the AI can now see environmental factors affecting colonist mood and health. Previously blind to lighting and beauty distribution, the AI can now:

- Diagnose "Why are my colonists unhappy?" by checking dark/ugly rooms
- Answer "Where should I place lamps?" by analyzing light coverage
- Verify "Is my mountain base safe?" via roof breach detection
- Track pollution impact (Biotech) on colonist health

Closes #63