### PR TITLE
docs: Teach AI to use new spatial query tools

### DIFF
--- a/Source/RimMind/Tools/BuildingTools.cs
+++ b/Source/RimMind/Tools/BuildingTools.cs
@@ -1684,6 +1684,12 @@ namespace RimMind.Tools
             int x = args["x"].AsInt;
             int z = args["z"].AsInt;
             var pos = new IntVec3(x, 0, z);
+            
+            // Validate position is in bounds
+            if (!pos.InBounds(map))
+            {
+                return ToolExecutor.JsonError($"Position ({x}, {z}) is outside map bounds (map size: {map.Size.x}x{map.Size.z})");
+            }
 
             // Resolve building def
             var def = ResolveBuildingDef(buildingDefName);


### PR DESCRIPTION
Week 3 of #94

Added Building & Spatial Planning section to CLAUDE.md explaining how to use the new spatial query tools:
- find_buildable_area
- check_placement  
- get_requirements

Includes workflow guidance and explains why these tools should be used instead of manual grid parsing.