### PR TITLE
fix: sanitize CI artifact name to remove forward slashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,13 @@ jobs:
         cp -r Defs/* staging/Defs/
         cp -r Languages staging/Languages
 
+    - name: Sanitize ref name for artifact
+      id: ref
+      run: echo "name=$(echo '${{ github.ref_name }}' | tr '/' '-')" >> $GITHUB_OUTPUT
+
     - name: Upload mod artifact
       uses: actions/upload-artifact@v4
       with:
-        name: RimMind-${{ github.ref_name }}
+        name: RimMind-${{ steps.ref.outputs.name }}
         path: staging/
         retention-days: 30


### PR DESCRIPTION
## Problem

`github.ref_name` for PRs returns `132/merge` (or similar), which contains a forward slash — not allowed in artifact names.

## Fix

Add a sanitize step that replaces `/` with `-` using `tr`, then use that in the artifact name.

**Before:** `RimMind-132/merge` ❌
**After:** `RimMind-132-merge` ✅