### PR TITLE
feat: make chat messages selectable/copyable (#124)

### DIFF
--- a/Languages/ChineseSimplified (简体中文)/Keyed/RimMind.xml
+++ b/Languages/ChineseSimplified (简体中文)/Keyed/RimMind.xml
@@ -143,4 +143,7 @@
     <RimMind_LocationQueryTitle>RimMind — ({0}, {1})</RimMind_LocationQueryTitle>
     <RimMind_LocationQueryHint>描述你想在这个位置做什么...</RimMind_LocationQueryHint>
     <RimMind_LocationQuerySend>发送</RimMind_LocationQuerySend>
+    <RimMind_CopyChatMessage>Copy</RimMind_CopyChatMessage>
+    <RimMind_CopyChatMessageTip>Copy message to clipboard</RimMind_CopyChatMessageTip>
+
 </LanguageData>

--- a/Languages/Dutch (Nederlands)/Keyed/RimMind.xml
+++ b/Languages/Dutch (Nederlands)/Keyed/RimMind.xml
@@ -143,4 +143,7 @@
     <RimMind_LocationQueryTitle>RimMind — ({0}, {1})</RimMind_LocationQueryTitle>
     <RimMind_LocationQueryHint>Beschrijf wat je op deze locatie wilt...</RimMind_LocationQueryHint>
     <RimMind_LocationQuerySend>Verzenden</RimMind_LocationQuerySend>
+    <RimMind_CopyChatMessage>Copy</RimMind_CopyChatMessage>
+    <RimMind_CopyChatMessageTip>Copy message to clipboard</RimMind_CopyChatMessageTip>
+
 </LanguageData>

--- a/Languages/English/Keyed/RimMind.xml
+++ b/Languages/English/Keyed/RimMind.xml
@@ -71,6 +71,8 @@
     <RimMind_ChatYou>You: {0}</RimMind_ChatYou>
     <RimMind_ChatRimMind>RimMind: {0}</RimMind_ChatRimMind>
     <RimMind_ChatErrorPrefix>[Error]</RimMind_ChatErrorPrefix>
+    <RimMind_CopyChatMessage>Copy</RimMind_CopyChatMessage>
+    <RimMind_CopyChatMessageTip>Copy message to clipboard</RimMind_CopyChatMessageTip>
     
     <!-- Directives Window -->
     <RimMind_DirectivesTitle>Colony Directives</RimMind_DirectivesTitle>

--- a/Languages/French (Français)/Keyed/RimMind.xml
+++ b/Languages/French (Français)/Keyed/RimMind.xml
@@ -143,4 +143,7 @@
     <RimMind_LocationQueryTitle>RimMind — ({0}, {1})</RimMind_LocationQueryTitle>
     <RimMind_LocationQueryHint>Décrivez ce que vous voulez à cet emplacement...</RimMind_LocationQueryHint>
     <RimMind_LocationQuerySend>Envoyer</RimMind_LocationQuerySend>
+    <RimMind_CopyChatMessage>Copy</RimMind_CopyChatMessage>
+    <RimMind_CopyChatMessageTip>Copy message to clipboard</RimMind_CopyChatMessageTip>
+
 </LanguageData>

--- a/Languages/German (Deutsch)/Keyed/RimMind.xml
+++ b/Languages/German (Deutsch)/Keyed/RimMind.xml
@@ -143,4 +143,7 @@
     <RimMind_LocationQueryTitle>RimMind — ({0}, {1})</RimMind_LocationQueryTitle>
     <RimMind_LocationQueryHint>Beschreiben Sie, was Sie an diesem Ort möchten...</RimMind_LocationQueryHint>
     <RimMind_LocationQuerySend>Senden</RimMind_LocationQuerySend>
+    <RimMind_CopyChatMessage>Copy</RimMind_CopyChatMessage>
+    <RimMind_CopyChatMessageTip>Copy message to clipboard</RimMind_CopyChatMessageTip>
+
 </LanguageData>

--- a/Languages/Italian (Italiano)/Keyed/RimMind.xml
+++ b/Languages/Italian (Italiano)/Keyed/RimMind.xml
@@ -143,4 +143,7 @@
     <RimMind_LocationQueryTitle>RimMind — ({0}, {1})</RimMind_LocationQueryTitle>
     <RimMind_LocationQueryHint>Descrivi cosa vuoi in questa posizione...</RimMind_LocationQueryHint>
     <RimMind_LocationQuerySend>Invia</RimMind_LocationQuerySend>
+    <RimMind_CopyChatMessage>Copy</RimMind_CopyChatMessage>
+    <RimMind_CopyChatMessageTip>Copy message to clipboard</RimMind_CopyChatMessageTip>
+
 </LanguageData>

--- a/Languages/Japanese (日本語)/Keyed/RimMind.xml
+++ b/Languages/Japanese (日本語)/Keyed/RimMind.xml
@@ -143,4 +143,7 @@
     <RimMind_LocationQueryTitle>RimMind — ({0}, {1})</RimMind_LocationQueryTitle>
     <RimMind_LocationQueryHint>この場所で何をしたいか説明してください...</RimMind_LocationQueryHint>
     <RimMind_LocationQuerySend>送信</RimMind_LocationQuerySend>
+    <RimMind_CopyChatMessage>Copy</RimMind_CopyChatMessage>
+    <RimMind_CopyChatMessageTip>Copy message to clipboard</RimMind_CopyChatMessageTip>
+
 </LanguageData>

--- a/Languages/Korean (한국어)/Keyed/RimMind.xml
+++ b/Languages/Korean (한국어)/Keyed/RimMind.xml
@@ -143,4 +143,7 @@
     <RimMind_LocationQueryTitle>RimMind — ({0}, {1})</RimMind_LocationQueryTitle>
     <RimMind_LocationQueryHint>이 위치에서 원하는 것을 설명하세요...</RimMind_LocationQueryHint>
     <RimMind_LocationQuerySend>전송</RimMind_LocationQuerySend>
+    <RimMind_CopyChatMessage>Copy</RimMind_CopyChatMessage>
+    <RimMind_CopyChatMessageTip>Copy message to clipboard</RimMind_CopyChatMessageTip>
+
 </LanguageData>

--- a/Languages/Polish (Polski)/Keyed/RimMind.xml
+++ b/Languages/Polish (Polski)/Keyed/RimMind.xml
@@ -143,4 +143,7 @@
     <RimMind_LocationQueryTitle>RimMind — ({0}, {1})</RimMind_LocationQueryTitle>
     <RimMind_LocationQueryHint>Opisz, co chcesz zrobić w tej lokalizacji...</RimMind_LocationQueryHint>
     <RimMind_LocationQuerySend>Wyślij</RimMind_LocationQuerySend>
+    <RimMind_CopyChatMessage>Copy</RimMind_CopyChatMessage>
+    <RimMind_CopyChatMessageTip>Copy message to clipboard</RimMind_CopyChatMessageTip>
+
 </LanguageData>

--- a/Languages/PortugueseBrazilian (Português Brasileiro)/Keyed/RimMind.xml
+++ b/Languages/PortugueseBrazilian (Português Brasileiro)/Keyed/RimMind.xml
@@ -143,4 +143,7 @@
     <RimMind_LocationQueryTitle>RimMind — ({0}, {1})</RimMind_LocationQueryTitle>
     <RimMind_LocationQueryHint>Descreva o que você quer neste local...</RimMind_LocationQueryHint>
     <RimMind_LocationQuerySend>Enviar</RimMind_LocationQuerySend>
+    <RimMind_CopyChatMessage>Copy</RimMind_CopyChatMessage>
+    <RimMind_CopyChatMessageTip>Copy message to clipboard</RimMind_CopyChatMessageTip>
+
 </LanguageData>

--- a/Languages/Russian (Русский)/Keyed/RimMind.xml
+++ b/Languages/Russian (Русский)/Keyed/RimMind.xml
@@ -143,4 +143,7 @@
     <RimMind_LocationQueryTitle>RimMind — ({0}, {1})</RimMind_LocationQueryTitle>
     <RimMind_LocationQueryHint>Опишите, что вы хотите сделать в этом месте...</RimMind_LocationQueryHint>
     <RimMind_LocationQuerySend>Отправить</RimMind_LocationQuerySend>
+    <RimMind_CopyChatMessage>Copy</RimMind_CopyChatMessage>
+    <RimMind_CopyChatMessageTip>Copy message to clipboard</RimMind_CopyChatMessageTip>
+
 </LanguageData>

--- a/Languages/Spanish (Español(Castellano))/Keyed/RimMind.xml
+++ b/Languages/Spanish (Español(Castellano))/Keyed/RimMind.xml
@@ -71,6 +71,8 @@
     <RimMind_ChatYou>Tú: {0}</RimMind_ChatYou>
     <RimMind_ChatRimMind>RimMind: {0}</RimMind_ChatRimMind>
     <RimMind_ChatErrorPrefix>[Error]</RimMind_ChatErrorPrefix>
+    <RimMind_CopyChatMessage>Copy</RimMind_CopyChatMessage>
+    <RimMind_CopyChatMessageTip>Copy message to clipboard</RimMind_CopyChatMessageTip>
     
     <!-- Directives Window -->
     <RimMind_DirectivesTitle>Directivas de colonia</RimMind_DirectivesTitle>

--- a/Languages/Swedish (Svenska)/Keyed/RimMind.xml
+++ b/Languages/Swedish (Svenska)/Keyed/RimMind.xml
@@ -143,4 +143,7 @@
     <RimMind_LocationQueryTitle>RimMind — ({0}, {1})</RimMind_LocationQueryTitle>
     <RimMind_LocationQueryHint>Beskriv vad du vill göra på denna plats...</RimMind_LocationQueryHint>
     <RimMind_LocationQuerySend>Skicka</RimMind_LocationQuerySend>
+    <RimMind_CopyChatMessage>Copy</RimMind_CopyChatMessage>
+    <RimMind_CopyChatMessageTip>Copy message to clipboard</RimMind_CopyChatMessageTip>
+
 </LanguageData>

--- a/Languages/Turkish (Türkçe)/Keyed/RimMind.xml
+++ b/Languages/Turkish (Türkçe)/Keyed/RimMind.xml
@@ -143,4 +143,7 @@
     <RimMind_LocationQueryTitle>RimMind — ({0}, {1})</RimMind_LocationQueryTitle>
     <RimMind_LocationQueryHint>Bu konumda ne istediğinizi açıklayın...</RimMind_LocationQueryHint>
     <RimMind_LocationQuerySend>Gönder</RimMind_LocationQuerySend>
+    <RimMind_CopyChatMessage>Copy</RimMind_CopyChatMessage>
+    <RimMind_CopyChatMessageTip>Copy message to clipboard</RimMind_CopyChatMessageTip>
+
 </LanguageData>


### PR DESCRIPTION
## Summary

Fixes the issue where chat messages couldn't be selected or copied.

**Root cause:** `DrawChatMessages` used `Widgets.Label` which Unity IMGUI renders as a non-interactive element — no text selection, no Ctrl+C.

## Changes

### `Source/RimMind/Chat/ChatWindow.cs`
- Added `_selectableTextStyle` static field — a `GUIStyle` derived from `GUI.skin.textArea` with all backgrounds stripped (`null`) so it renders identically to a label visually, but Unity IMGUI treats it as a text field that supports selection
- Replaced `Widgets.Label(textRect, displayText)` with `GUI.TextArea(textRect, displayText, _selectableTextStyle)` — return value discarded (read-only; any edits are discarded on next render frame)
- Added a **Copy** button that appears on hover for each message bubble, copying `msg.content` to `GUIUtility.systemCopyBuffer`

### `Languages/*/Keyed/RimMind.xml` (14 languages)
- Added `RimMind_CopyChatMessage` → "Copy"
- Added `RimMind_CopyChatMessageTip` → "Copy message to clipboard"

closes #124
