### PR TITLE
fix: expose pawn ID in list_animals response

### DIFF
--- a/Source/RimMind/Tools/AnimalTools.cs
+++ b/Source/RimMind/Tools/AnimalTools.cs
@@ -20,6 +20,7 @@ namespace RimMind.Tools
                 if (!animal.RaceProps.Animal) continue;
 
                 var obj = new JSONObject();
+                obj["id"] = animal.thingIDNumber;
                 obj["name"] = animal.Name?.ToStringShort ?? animal.LabelShort;
                 obj["species"] = animal.kindDef?.label ?? "Unknown";
                 obj["gender"] = animal.gender.ToString();


### PR DESCRIPTION
## Problem

`list_animals` did not include the animal's `id` (thingIDNumber) in its response. This forced RimMind to guess IDs when calling `designate_slaughter`, causing failures like:

```
designate_slaughter with ids: [1]  // guessed — not Holly's actual ID
→ status: not_found
```

## Fix

Add `obj["id"] = animal.thingIDNumber` as the first field in the `ListAnimals()` response. The correct flow is now possible:

1. `list_animals` → extract `id` from the matching animal
2. `designate_slaughter` with `ids: [actual_id]`

## Root Cause

Reported via RimMind self-generated debug report. The tool design broke the intended usage pattern documented in `designate_slaughter`'s own docstring: *"Primary: ids array for exact targeting (from list_animals)"* — but `list_animals` never exposed those IDs.

Closes #N/A (no issue — direct bug report from AI self-debugging)