### PR TITLE
fix: copy button click intercepted by TextArea in IMGUI

### DIFF
--- a/Source/RimMind/Chat/ChatWindow.cs
+++ b/Source/RimMind/Chat/ChatWindow.cs
@@ -411,24 +411,34 @@ namespace RimMind.Chat
                 _selectableTextStyle.active.textColor  = textColor;
 
                 GUI.color = Color.white;
+
+                // Copy button — visible only while cursor is over this bubble and not multi-selecting.
+                // IMPORTANT: compute the button rect and intercept the MouseDown event BEFORE drawing
+                // GUI.TextArea, because TextArea's rect overlaps the button area and would otherwise
+                // consume the click first, making the button appear to do nothing.
+                bool showCopyBtn = isOver && !multiSelectActive;
+                const float copyBtnW = 50f;
+                const float copyBtnH = 18f;
+                var copyBtnRect = new Rect(
+                    bubbleRect.xMax - copyBtnW - 4f,
+                    bubbleRect.y + 2f,
+                    copyBtnW,
+                    copyBtnH
+                );
+                if (showCopyBtn
+                    && Event.current.type == EventType.MouseDown
+                    && copyBtnRect.Contains(Event.current.mousePosition))
+                {
+                    GUIUtility.systemCopyBuffer = msg.content ?? "";
+                    Event.current.Use(); // prevent TextArea from stealing this click
+                }
+
                 GUI.TextArea(textRect, displayText, _selectableTextStyle);
 
-                // Copy button — visible only while cursor is over this bubble and not multi-selecting
-                if (isOver && !multiSelectActive)
+                if (showCopyBtn)
                 {
-                    const float copyBtnW = 50f;
-                    const float copyBtnH = 18f;
-                    var copyBtnRect = new Rect(
-                        bubbleRect.xMax - copyBtnW - 4f,
-                        bubbleRect.y + 2f,
-                        copyBtnW,
-                        copyBtnH
-                    );
                     GUI.color = new Color(1f, 1f, 1f, 0.85f);
-                    if (Widgets.ButtonText(copyBtnRect, RimMindTranslations.Get("RimMind_CopyChatMessage")))
-                    {
-                        GUIUtility.systemCopyBuffer = msg.content ?? "";
-                    }
+                    Widgets.ButtonText(copyBtnRect, RimMindTranslations.Get("RimMind_CopyChatMessage")); // visual only — click handled above
                     GUI.color = Color.white;
                     TooltipHandler.TipRegion(copyBtnRect, RimMindTranslations.Get("RimMind_CopyChatMessageTip"));
                 }

--- a/Source/RimMind/Chat/ChatWindow.cs
+++ b/Source/RimMind/Chat/ChatWindow.cs
@@ -429,7 +429,7 @@ namespace RimMind.Chat
                     && Event.current.type == EventType.MouseDown
                     && copyBtnRect.Contains(Event.current.mousePosition))
                 {
-                    GUIUtility.systemCopyBuffer = msg.content ?? "";
+                    CopyToClipboard(msg.content ?? "");
                     Event.current.Use(); // prevent TextArea from stealing this click
                 }
 
@@ -460,7 +460,7 @@ namespace RimMind.Chat
                     if (sb.Length > 0) sb.AppendLine();
                     sb.Append(visibleMessageTexts[i]);
                 }
-                GUIUtility.systemCopyBuffer = sb.ToString();
+                CopyToClipboard(sb.ToString());
                 multiSelectActive = false;
                 multiSelectStart = -1;
                 multiSelectEnd = -1;
@@ -579,6 +579,18 @@ namespace RimMind.Chat
                 y += textHeight + 12f;
             }
             return y;
+        }
+
+        /// <summary>
+        /// Copies <paramref name="text"/> to the system clipboard.
+        /// Uses the TextEditor approach which is more reliable than assigning
+        /// GUIUtility.systemCopyBuffer directly in some Unity/RimWorld builds.
+        /// </summary>
+        private static void CopyToClipboard(string text)
+        {
+            var te = new TextEditor { text = text };
+            te.SelectAll();
+            te.Copy();
         }
     }
 


### PR DESCRIPTION
## Problem

The copy button (📋) on chat message bubbles was silently failing to copy anything to the clipboard.

## Root Cause

`GUI.TextArea` was drawn first, covering the full `textRect` which overlapped the copy button rect. In Unity IMGUI, `GUI.TextArea` intercepts mouse events across its entire bounds — so clicking the copy button area was consumed by the TextArea, and `Widgets.ButtonText` never registered the click.

Additionally, `GUIUtility.systemCopyBuffer` can silently fail in some Unity/RimWorld builds.

## Fix

1. Intercept `EventType.MouseDown` in the button rect **before** drawing `GUI.TextArea`, copy there, and call `Event.current.Use()` to prevent TextArea from stealing the event
2. Replace all clipboard writes with a `CopyToClipboard()` helper using `TextEditor.Copy()` — the reliable approach used by other RimWorld mods

## Testing

- Hover a chat bubble → copy button appears
- Click the button → text is in clipboard ✅
- Selecting text inside a bubble still works normally ✅
- Multi-select drag still works normally ✅

Fixes #124