### PR TITLE
feat: add move_pawns_batch for coordinated squad movement

### DIFF
--- a/Source/RimMind/Tools/ToolDefinitions.cs
+++ b/Source/RimMind/Tools/ToolDefinitions.cs
@@ -564,6 +564,8 @@ namespace RimMind.Tools
                 MakeParam("pawnName", "string", "Name of the pawn to move"),
                 MakeParam("x", "integer", "X coordinate to move to"),
                 MakeParam("z", "integer", "Z coordinate to move to")));
+            tools.Add(MakeTool("move_pawns_batch", "Move multiple drafted pawns to their respective destinations in a single call. Prefer this over multiple move_pawn calls when moving a squad or formation. All pawns must be drafted first. Partial success is allowed — each pawn reports success or failure independently. Same hold_position warning applies: do not call hold_position on any pawn immediately after this call.",
+                MakeParam("movements", "array", "Array of movement objects, each with: pawnName (string), x (integer), z (integer)")));
             tools.Add(MakeTool("order_attack", "Order a drafted pawn to attack a specific target pawn or animal. Automatically uses ranged or melee attack based on the pawn's equipped weapon. Pawn must be drafted first. Target name supports exact and partial matching. Returns error if pawn is not drafted, is downed, or target is not found on the map.",
                 MakeParam("pawnName", "string", "Name of the pawn to give the attack order to"),
                 MakeParam("targetName", "string", "Name of the target pawn or animal to attack")));

--- a/Source/RimMind/Tools/ToolExecutor.cs
+++ b/Source/RimMind/Tools/ToolExecutor.cs
@@ -241,6 +241,7 @@ namespace RimMind.Tools
 
             // Drafted Pawn Commands
             { "move_pawn", args => DraftedPawnTools.MovePawn(args?["pawnName"]?.Value, args?["x"]?.AsInt ?? -1, args?["z"]?.AsInt ?? -1) },
+            { "move_pawns_batch", args => DraftedPawnTools.MovePawnsBatch(args?["movements"]) },
             { "order_attack", args => DraftedPawnTools.OrderAttack(args?["pawnName"]?.Value, args?["targetName"]?.Value) },
             { "hold_position", args => DraftedPawnTools.HoldPosition(args?["pawnName"]?.Value) },
             { "order_group_attack", args => DraftedPawnTools.OrderGroupAttack(DraftedPawnTools.ExtractPawnNames(args?["pawnNames"]), args?["targetName"]?.Value) },


### PR DESCRIPTION
## Feature Request

Add `move_pawns_batch` — a single call to move multiple drafted pawns to their respective destinations simultaneously.

## Usage

```json
move_pawns_batch({
  "movements": [
    {"pawnName": "Fluffy", "x": 148, "z": 137},
    {"pawnName": "Dan",    "x": 150, "z": 135},
    {"pawnName": "Florine","x": 140, "z": 130}
  ]
})
```

## Response

```json
{
  "totalOrdered": 3,
  "successCount": 3,
  "failCount": 0,
  "movements": [
    {"pawnName": "Fluffy", "success": true, "destination": "(148, 137)", "action": "moving"},
    ...
  ]
}
```

## Details

- Same validation as `move_pawn` per pawn (drafted, not downed, in bounds, standable, reachable)
- Partial success — some pawns can fail while others succeed
- Tool description includes the `hold_position` warning from PR #140
- Mirrors `order_group_attack` pattern for consistency

Requested by Jacob.