### PR TITLE
fix: haul job queueing + add haul_all_of_type tool

### DIFF
--- a/Source/RimMind/Tools/ToolDefinitions.cs
+++ b/Source/RimMind/Tools/ToolDefinitions.cs
@@ -82,10 +82,13 @@ namespace RimMind.Tools
             tools.Add(MakeTool("prioritize_tend", "Force a doctor to immediately tend to a patient.",
                 MakeParam("doctor", "string", "The doctor's name"),
                 MakeParam("patient", "string", "The patient's name")));
-            tools.Add(MakeTool("prioritize_haul", "Force a colonist to haul a specific item at the given coordinates.",
+            tools.Add(MakeTool("prioritize_haul", "Force a colonist to haul a specific item at the given coordinates. If the colonist is already hauling, the new job is queued after the current one. For hauling all items of a type (e.g. 'haul all silver'), use haul_all_of_type instead — this tool only targets one location at a time.",
                 MakeParam("colonist", "string", "The colonist's name"),
                 MakeParam("x", "integer", "X coordinate of the item"),
                 MakeParam("z", "integer", "Z coordinate of the item")));
+            tools.Add(MakeTool("haul_all_of_type", "Find all items of a given type anywhere on the map and queue haul jobs for all of them. Use this when the player says 'haul all [resource]' or 'clear all [item]'. Jobs are queued in order from nearest to farthest (capped at 30). Returns the full list of items queued with their positions and stack counts.",
+                MakeParam("colonist", "string", "The colonist's name"),
+                MakeParam("itemType", "string", "Item type to haul — matches by label or defName (e.g. 'silver', 'medicine', 'steel')")));
             tools.Add(MakeTool("prioritize_repair", "Force a colonist to repair a damaged building at the given coordinates.",
                 MakeParam("colonist", "string", "The colonist's name"),
                 MakeParam("x", "integer", "X coordinate of the building"),

--- a/Source/RimMind/Tools/ToolExecutor.cs
+++ b/Source/RimMind/Tools/ToolExecutor.cs
@@ -41,6 +41,7 @@ namespace RimMind.Tools
             { "prioritize_rescue", args => JobTools.PrioritizeRescue(args?["colonist"]?.Value, args?["target"]?.Value) },
             { "prioritize_tend", args => JobTools.PrioritizeTend(args?["doctor"]?.Value, args?["patient"]?.Value) },
             { "prioritize_haul", args => JobTools.PrioritizeHaul(args?["colonist"]?.Value, args?["x"]?.AsInt ?? -1, args?["z"]?.AsInt ?? -1) },
+            { "haul_all_of_type", args => JobTools.HaulAllOfType(args?["colonist"]?.Value, args?["itemType"]?.Value) },
             { "prioritize_repair", args => JobTools.PrioritizeRepair(args?["colonist"]?.Value, args?["x"]?.AsInt ?? -1, args?["z"]?.AsInt ?? -1) },
             { "prioritize_clean", args => JobTools.PrioritizeClean(args?["colonist"]?.Value, args?["x"]?.AsInt ?? -1, args?["z"]?.AsInt ?? -1, args?["radius"]?.AsInt ?? 5) },
 


### PR DESCRIPTION
## Two bugs, one PR

### Bug 1: `prioritize_haul` overwrites instead of queuing

Calling `prioritize_haul` twice on the same colonist dropped the first job. The second call used bare `TryTakeOrderedJob` which always interrupts.

**Fix:** Apply `TakeOrQueueHaulJob` helper (same pattern as the `wear_apparel` fix from #134). Checks if pawn is already hauling — if so, queues via `requestQueueing: true` instead of interrupting.

### Bug 2: No tool for "haul all [resource]"

When asked *"haul all the silver"*, the AI had no way to find all silver on the map. It fell back to picking one stack at one coordinate — missing the user's intent entirely.

**Fix:** New tool `haul_all_of_type(colonist, itemType)`
- Searches entire map for matching haulable Things (label/defName match)
- Queues all of them nearest-first, capped at 30
- Returns full list with positions and stack counts

**Example:**
```json
haul_all_of_type({ "colonist": "Dan", "itemType": "silver" })
// → queues jobs for all silver stacks on the map
```

Also updated `prioritize_haul` description to steer AI toward `haul_all_of_type` for 'haul all X' intents.

Reported via RimMind self-debug report (Jacob).