### PR TITLE
feat: job completion callbacks — defer draft/undraft until active jobs finish

### DIFF
--- a/Source/RimMind/Core/JobCompletionPatch.cs
+++ b/Source/RimMind/Core/JobCompletionPatch.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Reflection;
+using HarmonyLib;
+using Verse;
+using Verse.AI;
+
+namespace RimMind.Core
+{
+    /// <summary>
+    /// Harmony patch on JobDriver.EndJobWith.
+    /// When a player-forced job completes successfully, fires the next pending callback for that pawn.
+    /// This allows instant state changes (draft, undraft) to be deferred until after jobs complete.
+    /// </summary>
+    public static class JobCompletionPatch
+    {
+        public static void Apply(Harmony harmony)
+        {
+            var target = typeof(JobDriver).GetMethod(
+                "EndJobWith",
+                BindingFlags.Public | BindingFlags.Instance);
+
+            if (target == null)
+            {
+                Log.Error("[RimMind] Could not find JobDriver.EndJobWith to patch!");
+                return;
+            }
+
+            var postfix = typeof(JobCompletionPatch).GetMethod(
+                "Postfix",
+                BindingFlags.Static | BindingFlags.Public);
+
+            harmony.Patch(target, postfix: new HarmonyMethod(postfix));
+            Log.Message("[RimMind] Patched JobDriver.EndJobWith for callback queue");
+        }
+
+        public static void Postfix(JobDriver __instance, JobCondition condition)
+        {
+            try
+            {
+                // Only fire on successful completion of player-issued jobs
+                if (condition != JobCondition.Succeeded) return;
+                if (__instance?.job == null || !__instance.job.playerForced) return;
+
+                var pawn = __instance.pawn;
+                if (pawn == null || pawn.Destroyed) return;
+
+                if (PendingCallbackQueue.HasPending(pawn))
+                {
+                    // Check if there are more queued jobs before firing — if so, wait for all to finish
+                    if (pawn.jobs.jobQueue.Count > 0) return;
+                    PendingCallbackQueue.FireNext(pawn);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("[RimMind] JobCompletionPatch failed: " + ex);
+            }
+        }
+    }
+}

--- a/Source/RimMind/Core/PendingCallbackQueue.cs
+++ b/Source/RimMind/Core/PendingCallbackQueue.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using Verse;
+
+namespace RimMind.Core
+{
+    /// <summary>
+    /// Holds deferred actions for pawns that need to execute after their current job completes.
+    /// Used to sequence instant state changes (draft, undraft) after job-based actions (equip, haul).
+    /// </summary>
+    public static class PendingCallbackQueue
+    {
+        private static readonly Dictionary<Pawn, Queue<Action>> _pending = new Dictionary<Pawn, Queue<Action>>();
+
+        public static void Register(Pawn pawn, Action callback)
+        {
+            if (!_pending.ContainsKey(pawn))
+                _pending[pawn] = new Queue<Action>();
+            _pending[pawn].Enqueue(callback);
+        }
+
+        public static void FireNext(Pawn pawn)
+        {
+            if (!_pending.TryGetValue(pawn, out var queue) || queue.Count == 0) return;
+            var next = queue.Dequeue();
+            if (queue.Count == 0) _pending.Remove(pawn);
+            try { next?.Invoke(); }
+            catch (Exception ex) { Log.Error("[RimMind] PendingCallbackQueue callback failed: " + ex); }
+        }
+
+        public static bool HasPending(Pawn pawn) =>
+            _pending.TryGetValue(pawn, out var q) && q.Count > 0;
+
+        public static void Clear(Pawn pawn) => _pending.Remove(pawn);
+
+        public static void ClearAll() => _pending.Clear();
+    }
+}

--- a/Source/RimMind/Core/RimMindMod.cs
+++ b/Source/RimMind/Core/RimMindMod.cs
@@ -24,6 +24,9 @@ namespace RimMind.Core
                 // attribute-based patching causes AmbiguousMatchException)
                 Automation.LetterAutomationPatch.Apply(harmony);
 
+                // Patch JobDriver.EndJobWith to fire deferred callbacks (draft/undraft after equip/haul)
+                Core.JobCompletionPatch.Apply(harmony);
+
                 var patched = harmony.GetPatchedMethods();
                 int count = 0;
                 foreach (var m in patched) count++;

--- a/Source/RimMind/Tools/ToolDefinitions.cs
+++ b/Source/RimMind/Tools/ToolDefinitions.cs
@@ -18,9 +18,9 @@ namespace RimMind.Tools
                 MakeParam("name", "string", "The colonist's name (first name or nickname)")));
             tools.Add(MakeTool("get_colonist_health", "Get health details for a specific colonist: injuries, diseases, immunity progress, bionics/implants, pain level, and consciousness.",
                 MakeParam("name", "string", "The colonist's name")));
-            tools.Add(MakeTool("draft_colonist", "Draft a colonist for combat. Drafted colonists will follow orders instead of performing normal work tasks.",
+            tools.Add(MakeTool("draft_colonist", "Draft a colonist for combat. Drafted colonists will follow orders instead of performing normal work tasks. If the pawn has active player-ordered jobs (equip, haul, etc.), drafting is automatically deferred until they complete — response will include status:'draft_queued'.",
                 MakeParam("name", "string", "The colonist's name")));
-            tools.Add(MakeTool("undraft_colonist", "Undraft a colonist, returning them to normal work tasks.",
+            tools.Add(MakeTool("undraft_colonist", "Undraft a colonist, returning them to normal work tasks. If the pawn has active player-ordered jobs (equip, haul, etc.), drafting is automatically deferred until they complete — response will include status:'draft_queued'.",
                 MakeParam("name", "string", "The colonist's name")));
             tools.Add(MakeTool("draft_all", "Draft all colonists for combat at once."));
             tools.Add(MakeTool("undraft_all", "Undraft all colonists, returning them to normal work."));


### PR DESCRIPTION
## Problem

When the AI calls `equip_weapon(Dan, x, z)` followed immediately by `draft_colonist(Dan)`, the draft happens instantly before the pawn reaches the weapon. `draft_colonist` is an instant state change (`pawn.drafter.Drafted = true`) — it cannot sit in RimWorld's job queue.

## Solution

Introduces a **PendingCallbackQueue** system: a static pawn→action registry that defers instant state changes until after the pawn's current player-forced jobs complete.

## Changes

### New Files
- **`Core/PendingCallbackQueue.cs`** — Static registry mapping `Pawn → Queue<Action>`. Supports register, fire-next, has-pending, clear.
- **`Core/JobCompletionPatch.cs`** — Harmony postfix on `JobDriver.EndJobWith`. When a player-forced job succeeds and the pawn's job queue is empty, fires the next pending callback.

### Modified Files
- **`Core/RimMindMod.cs`** — Registers the `JobCompletionPatch` alongside `LetterAutomationPatch`.
- **`Tools/ColonistTools.cs`** — `DraftColonist` and `UndraftColonist` now check for active player-forced jobs. If the pawn is busy, the state change is registered as a callback and the response returns `status: 'draft_queued'` / `status: 'undraft_queued'` with an explanatory note.
- **`Tools/ToolDefinitions.cs`** — Updated `draft_colonist` and `undraft_colonist` descriptions to inform the AI about the deferred behaviour.

## Behaviour

| Scenario | Before | After |
|---|---|---|
| equip_weapon then draft_colonist (pawn busy) | Drafts instantly, pawn drops equip job | Returns draft_queued, drafts after equip completes |
| draft_colonist (pawn idle) | Drafts instantly | Drafts instantly (no change) |

## Build
Build succeeded: 0 errors, 0 warnings