### PR TITLE
fix: add preview image to Steam Workshop deploy

### DIFF
--- a/.github/workflows/deploy-steam.yml
+++ b/.github/workflows/deploy-steam.yml
@@ -49,4 +49,5 @@ jobs:
           appId: 294100
           publishedFileId: ${{ github.ref_name == 'main' && '3666997391' || '3668326181' }}
           path: staging
+          previewPath: staging/About/Preview.png
           changeNote: "${{ github.ref_name == 'dev' && '[DEV] ' || '' }}${{ github.event.head_commit.message }}"


### PR DESCRIPTION
## Description

The Steam Workshop deploy workflow was staging `About/Preview.png` but never uploading it as the workshop preview image. Added `previewPath` so the thumbnail shows up on the mod page.

Closes #155