### PR TITLE
fix: sanitize UTF-8 encoding to prevent illegal byte sequence crash

### DIFF
--- a/Source/RimMind/API/AnthropicClient.cs
+++ b/Source/RimMind/API/AnthropicClient.cs
@@ -44,7 +44,7 @@ namespace RimMind.API
                     httpRequest.Timeout = 120000;
                     httpRequest.ReadWriteTimeout = 120000;
 
-                    byte[] bodyBytes = Encoding.UTF8.GetBytes(jsonBody);
+                    byte[] bodyBytes = Encoding.UTF8.GetBytes(StringUtils.SanitizeForUTF8(jsonBody));
                     httpRequest.ContentLength = bodyBytes.Length;
 
                     using (var stream = httpRequest.GetRequestStream())

--- a/Source/RimMind/API/CustomProviderClient.cs
+++ b/Source/RimMind/API/CustomProviderClient.cs
@@ -72,7 +72,7 @@ namespace RimMind.API
                     httpRequest.Timeout = 120000;
                     httpRequest.ReadWriteTimeout = 120000;
 
-                    byte[] bodyBytes = Encoding.UTF8.GetBytes(jsonBody);
+                    byte[] bodyBytes = Encoding.UTF8.GetBytes(StringUtils.SanitizeForUTF8(jsonBody));
                     httpRequest.ContentLength = bodyBytes.Length;
 
                     using (var stream = httpRequest.GetRequestStream())

--- a/Source/RimMind/API/OpenRouterClient.cs
+++ b/Source/RimMind/API/OpenRouterClient.cs
@@ -44,7 +44,7 @@ namespace RimMind.API
                     httpRequest.Timeout = 60000;
                     httpRequest.ReadWriteTimeout = 60000;
 
-                    byte[] bodyBytes = Encoding.UTF8.GetBytes(jsonBody);
+                    byte[] bodyBytes = Encoding.UTF8.GetBytes(StringUtils.SanitizeForUTF8(jsonBody));
                     httpRequest.ContentLength = bodyBytes.Length;
 
                     using (var stream = httpRequest.GetRequestStream())

--- a/Source/RimMind/Core/StringUtils.cs
+++ b/Source/RimMind/Core/StringUtils.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Text;
+
+namespace RimMind.Core
+{
+    /// <summary>
+    /// Utility methods for safe string handling.
+    /// </summary>
+    public static class StringUtils
+    {
+        /// <summary>
+        /// Removes lone/invalid Unicode surrogates from a string so it can be safely
+        /// encoded as UTF-8. RimWorld game data can contain such characters (e.g. from
+        /// mods or localization), which cause Encoding.UTF8.GetBytes to throw
+        /// "Illegal byte sequence encountered in the input. Parameter name: string".
+        /// </summary>
+        public static string SanitizeForUTF8(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                return input;
+
+            var sb = new StringBuilder(input.Length);
+            for (int i = 0; i < input.Length; i++)
+            {
+                char c = input[i];
+                if (char.IsHighSurrogate(c))
+                {
+                    // Only include if followed by a valid low surrogate (valid surrogate pair)
+                    if (i + 1 < input.Length && char.IsLowSurrogate(input[i + 1]))
+                    {
+                        sb.Append(c);
+                        sb.Append(input[++i]);
+                    }
+                    // else: lone high surrogate — drop it
+                }
+                else if (char.IsLowSurrogate(c))
+                {
+                    // Lone low surrogate — drop it
+                }
+                else
+                {
+                    sb.Append(c);
+                }
+            }
+            return sb.ToString();
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes crash when RimWorld game data contains invalid Unicode surrogates (lone high/low surrogates). These can appear in colonist names, item labels, or modded content, causing all API providers to fail with 'Illegal byte sequence encountered in the input'.

Adds `StringUtils.SanitizeForUTF8()` and applies it in all three API clients before encoding the JSON body.