### PR TITLE
feat: add PR auto-review workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,27 @@
+name: PR Auto-Review
+
+on:
+  pull_request:
+    branches: [dev]
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: false
+        type: string
+
+jobs:
+  post-review-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post review triggered comment
+        run: |
+          PR_NUM="${{ github.event.pull_request.number || inputs.pr_number }}"
+          echo "=== RIMMIND REVIEW TRIGGERED ==="
+          echo "PR: https://github.com/Bwarhness/RimMind/pull/$PR_NUM"
+          echo "::notice::PR #$PR_NUM is ready for RimMind Auto-Review"
+
+# NOTE: The actual review is performed by the OpenClaw cron job on the server.
+# Every 5 minutes, rimmind-pr-reviewer.py polls GitHub for PRs to dev,
+# spawns reviewer + simplifier agents, and auto-merges if both approve.


### PR DESCRIPTION
## Description

Adds GitHub Actions workflow that notifies when a PR to `dev` is opened. The actual review (spawning reviewer + simplifier agents, auto-merge) is handled by the OpenClaw cron job every 5 minutes.

Also adds the `rimmind-simplifier` agent for checking code complexity.

Closes #161