### PR TITLE
feat: Colony Chronicle Phase 1 - weekly newspaper report

### DIFF
--- a/Source/RimMind/Chat/ChatWindow.cs
+++ b/Source/RimMind/Chat/ChatWindow.cs
@@ -221,6 +221,24 @@ namespace RimMind.Chat
                     Find.WindowStack.Add(new ContextViewWindow(chatManager));
             }
 
+            // Chronicle button (Colony Chronicle weekly newspaper)
+            btnX -= btnW + 4f;
+            GUI.color = Color.white;
+            if (Widgets.ButtonText(new Rect(btnX, btnY, btnW, btnH), "Chronicle"))
+            {
+                var existing = Find.WindowStack.WindowOfType<Chronicle.ChronicleTab>();
+                if (existing != null)
+                {
+                    Find.WindowStack.TryRemove(existing);
+                }
+                else
+                {
+                    var chronicleTab = new Chronicle.ChronicleTab();
+                    Find.WindowStack.Add(chronicleTab);
+                }
+            }
+            TooltipHandler.TipRegion(new Rect(btnX, btnY, btnW, btnH), "Open the Colony Chronicle - a newspaper-style weekly report");
+
             // Vision button (Spatial Vision debug window)
             btnX -= btnW + 4f;
             if (Widgets.ButtonText(new Rect(btnX, btnY, btnW, btnH), "Vision"))

--- a/Source/RimMind/Chronicle/ChronicleData.cs
+++ b/Source/RimMind/Chronicle/ChronicleData.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections.Generic;
+using Verse;
+
+namespace RimMind.Chronicle
+{
+    /// <summary>
+    /// Represents a single issue of the Colony Chronicle - a newspaper-style weekly report.
+    /// </summary>
+    public class WeeklyChronicle
+    {
+        public int weekNumber;
+        public int gameDay;
+        public string season;
+        public int year;
+        public string topHeadline;
+        public string leadParagraph;
+        public List<ChronicleSection> sections = new List<ChronicleSection>();
+        public List<ColonyEvent> events = new List<ColonyEvent>();
+        public List<ColonistQuote> quotes = new List<ColonistQuote>();
+        public List<string> milestones = new List<string>();
+        public string weatherPoem;
+        public string prediction;
+        public bool isGenerated;
+
+        public WeeklyChronicle()
+        {
+        }
+
+        public WeeklyChronicle(int weekNumber, int gameDay, string season, int year)
+        {
+            this.weekNumber = weekNumber;
+            this.gameDay = gameDay;
+            this.season = season;
+            this.year = year;
+            this.isGenerated = false;
+        }
+    }
+
+    /// <summary>
+    /// A newspaper-style section within the Chronicle.
+    /// </summary>
+    public class ChronicleSection
+    {
+        public string title;
+        public string emoji;
+        public string content;
+
+        public ChronicleSection()
+        {
+        }
+
+        public ChronicleSection(string title, string emoji, string content)
+        {
+            this.title = title;
+            this.emoji = emoji;
+            this.content = content;
+        }
+    }
+
+    /// <summary>
+    /// Represents a significant event that occurred during the week.
+    /// </summary>
+    public class ColonyEvent
+    {
+        public string type;       // "death", "raid", "milestone", "trade", "birth", "mental_break"
+        public string headline;
+        public string colonist;
+        public int day;
+        public string details;
+
+        public ColonyEvent()
+        {
+        }
+
+        public ColonyEvent(string type, string headline, string colonist = null, int day = 0, string details = null)
+        {
+            this.type = type;
+            this.headline = headline;
+            this.colonist = colonist;
+            this.day = day;
+            this.details = details;
+        }
+    }
+
+    /// <summary>
+    /// A colonist's quote or saying from the week.
+    /// </summary>
+    public class ColonistQuote
+    {
+        public string colonistName;
+        public string quote;
+        public string mood; // "happy", "sad", "angry", "neutral"
+
+        public ColonistQuote()
+        {
+        }
+
+        public ColonistQuote(string colonistName, string quote, string mood = "neutral")
+        {
+            this.colonistName = colonistName;
+            this.quote = quote;
+            this.mood = mood;
+        }
+    }
+
+    /// <summary>
+    /// Tracks event data accumulated throughout the current week.
+    /// Used internally by ChronicleTracker to build the weekly report.
+    /// </summary>
+    public class WeeklyEventLog
+    {
+        public int weekNumber;
+        public int startDay;
+        public int endDay;
+        public string season;
+        public int year;
+
+        public List<ColonyEvent> events = new List<ColonyEvent>();
+        public List<ColonistQuote> quotes = new List<ColonistQuote>();
+        public List<string> milestones = new List<string>();
+
+        // Stats for the week
+        public int deaths;
+        public int raids;
+        public int trades;
+        public int births;
+        public int mentalBreaks;
+        public int surgeries;
+        public int researchCompleted;
+        public int animalsTamed;
+        public int itemsCrafted;
+
+        // Weather tracking
+        public List<string> weatherEvents = new List<string>();
+
+        // Extremes
+        public float highestWealth;
+        public float lowestWealth;
+        public int highestColonistCount;
+        public int lowestColonistCount;
+        public string mostExtremeMoodColonist;
+        public float mostExtremeMoodValue;
+
+        public WeeklyEventLog()
+        {
+        }
+
+        public WeeklyEventLog(int weekNumber, int startDay, int endDay, string season, int year)
+        {
+            this.weekNumber = weekNumber;
+            this.startDay = startDay;
+            this.endDay = endDay;
+            this.season = season;
+            this.year = year;
+        }
+
+        public void Reset(int weekNumber, int startDay, int endDay, string season, int year)
+        {
+            this.weekNumber = weekNumber;
+            this.startDay = startDay;
+            this.endDay = endDay;
+            this.season = season;
+            this.year = year;
+
+            events.Clear();
+            quotes.Clear();
+            milestones.Clear();
+
+            deaths = 0;
+            raids = 0;
+            trades = 0;
+            births = 0;
+            mentalBreaks = 0;
+            surgeries = 0;
+            researchCompleted = 0;
+            animalsTamed = 0;
+            itemsCrafted = 0;
+
+            weatherEvents.Clear();
+
+            highestWealth = 0f;
+            lowestWealth = float.MaxValue;
+            highestColonistCount = 0;
+            lowestColonistCount = int.MaxValue;
+            mostExtremeMoodColonist = null;
+            mostExtremeMoodValue = 0.5f;
+        }
+
+        public string BuildContextSummary()
+        {
+            var sb = new System.Text.StringBuilder();
+
+            sb.AppendLine($"=== WEEK {weekNumber} CHRONICLE DATA ===");
+            sb.AppendLine($"Period: Day {startDay} to Day {endDay}, {season}, Year {year}");
+            sb.AppendLine();
+
+            sb.AppendLine("-- EVENTS --");
+            if (events.Count == 0)
+            {
+                sb.AppendLine("A quiet week with no major events.");
+            }
+            else
+            {
+                foreach (var evt in events)
+                {
+                    sb.AppendLine($"[{evt.type.ToUpper()}] Day {evt.day}: {evt.headline}");
+                    if (!string.IsNullOrEmpty(evt.colonist))
+                        sb.AppendLine($"  Colonist: {evt.colonist}");
+                }
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("-- COLONIST QUOTES --");
+            if (quotes.Count == 0)
+            {
+                sb.AppendLine("No memorable quotes recorded this week.");
+            }
+            else
+            {
+                foreach (var q in quotes)
+                {
+                    sb.AppendLine($"\"{q.quote}\" — {q.colonistName}");
+                }
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("-- MILESTONES --");
+            if (milestones.Count == 0)
+            {
+                sb.AppendLine("No major milestones reached.");
+            }
+            else
+            {
+                foreach (var m in milestones)
+                {
+                    sb.AppendLine($"* {m}");
+                }
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("-- WEEKLY STATISTICS --");
+            sb.AppendLine($"Deaths: {deaths}");
+            sb.AppendLine($"Raids/Attacks: {raids}");
+            sb.AppendLine($"Trades: {trades}");
+            sb.AppendLine($"Births: {births}");
+            sb.AppendLine($"Mental Breaks: {mentalBreaks}");
+            sb.AppendLine($"Surgeries: {surgeries}");
+            sb.AppendLine($"Research Completed: {researchCompleted}");
+            sb.AppendLine($"Animals Tamed: {animalsTamed}");
+            sb.AppendLine($"Items Crafted: {itemsCrafted}");
+
+            sb.AppendLine();
+            sb.AppendLine("-- WEATHER --");
+            if (weatherEvents.Count == 0)
+            {
+                sb.AppendLine("No notable weather events.");
+            }
+            else
+            {
+                foreach (var w in weatherEvents)
+                {
+                    sb.AppendLine($"* {w}");
+                }
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("-- COLONY STANDINGS --");
+            sb.AppendLine($"Wealth: {highestWealth:N0} (peak), {lowestWealth:N0} (low)");
+            sb.AppendLine($"Colonists: {highestColonistCount} (peak), {lowestColonistCount} (low)");
+            if (!string.IsNullOrEmpty(mostExtremeMoodColonist))
+            {
+                sb.AppendLine($"Most Emotional: {mostExtremeMoodColonist} at {mostExtremeMoodValue:P0} mood");
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/Source/RimMind/Chronicle/ChronicleTab.cs
+++ b/Source/RimMind/Chronicle/ChronicleTab.cs
@@ -1,0 +1,453 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Verse;
+using RimMind.Core;
+
+namespace RimMind.Chronicle
+{
+    /// <summary>
+    /// UI window for displaying the Colony Chronicle in a newspaper-style format.
+    /// This is opened as a tab within the RimMind window system.
+    /// </summary>
+    public class ChronicleTab : Window
+    {
+        private const float PARCHMENT_ALPHA = 0.95f;
+        private const float COLUMN_GAP = 12f;
+        private const float SECTION_MARGIN = 8f;
+        private const float LINE_HEIGHT = 14f;
+
+        // Parchment colors
+        private static readonly Color PARCHMENT_COLOR = new Color(0.96f, 0.90f, 0.78f, PARCHMENT_ALPHA);
+        private static readonly Color INK_COLOR = new Color(0.15f, 0.10f, 0.05f, 1f);
+        private static readonly Color HEADLINE_COLOR = new Color(0.10f, 0.05f, 0.02f, 1f);
+        private static readonly Color COLUMN_LINE_COLOR = new Color(0.6f, 0.5f, 0.3f, 0.5f);
+        private static readonly Color SEPARATOR_COLOR = new Color(0.4f, 0.3f, 0.2f, 0.4f);
+
+        private Vector2 scrollPosition;
+        private float totalHeight;
+        private WeeklyChronicle chronicle;
+        private bool isLoading;
+        private string loadingMessage = "Loading Chronicle...";
+
+        public override Vector2 InitialSize => new Vector2(650f, 700f);
+
+        public ChronicleTab()
+        {
+            doCloseX = true;
+            draggable = true;
+            resizeable = true;
+            closeOnClickedOutside = false;
+            closeOnAccept = false;
+            absorbInputAroundWindow = false;
+            forcePause = false;
+
+            RefreshChronicle();
+        }
+
+        /// <summary>
+        /// Refresh the chronicle from the tracker.
+        /// </summary>
+        public void RefreshChronicle()
+        {
+            chronicle = null;
+            isLoading = true;
+
+            if (ChronicleTracker.Instance != null)
+            {
+                chronicle = ChronicleTracker.Instance.GetCurrentChronicle();
+
+                if (ChronicleTracker.Instance.IsGeneratingChronicle)
+                {
+                    isLoading = true;
+                    loadingMessage = "Generating Chronicle...";
+                }
+                else if (chronicle == null)
+                {
+                    loadingMessage = "No Chronicle available yet. Check back at the end of the week!";
+                }
+            }
+            else
+            {
+                loadingMessage = "Chronicle system not initialized.";
+            }
+
+            if (chronicle != null)
+                isLoading = false;
+        }
+
+        public override void DoWindowContents(Rect inRect)
+        {
+            // Draw parchment background
+            DrawParchmentBackground(inRect);
+
+            if (isLoading)
+            {
+                DrawLoadingState(inRect);
+                return;
+            }
+
+            if (chronicle == null)
+            {
+                DrawNoChronicleState(inRect);
+                return;
+            }
+
+            // Draw the chronicle content
+            DrawChronicleContent(inRect);
+        }
+
+        private void DrawParchmentBackground(Rect inRect)
+        {
+            // Main parchment background
+            Widgets.DrawBoxSolid(inRect, PARCHMENT_COLOR);
+
+            // Add subtle aged paper texture effect (simple noise pattern via alternating pixels)
+            // This is stylized - just draw a border to look like worn paper
+            float borderWidth = 3f;
+
+            // Outer border - darker ink
+            GUI.color = new Color(0.5f, 0.4f, 0.3f, 0.6f);
+            Widgets.DrawBox(new Rect(inRect.x, inRect.y, inRect.width, borderWidth));
+            Widgets.DrawBox(new Rect(inRect.x, inRect.yMax - borderWidth, inRect.width, borderWidth));
+            Widgets.DrawBox(new Rect(inRect.x, inRect.y, borderWidth, inRect.height));
+            Widgets.DrawBox(new Rect(inRect.xMax - borderWidth, inRect.y, borderWidth, inRect.height));
+
+            // Inner border - lighter
+            GUI.color = new Color(0.6f, 0.5f, 0.35f, 0.3f);
+            Widgets.DrawBox(new Rect(inRect.x + 6f, inRect.y + 6f, inRect.width - 12f, 1f));
+            Widgets.DrawBox(new Rect(inRect.x + 6f, inRect.yMax - 7f, inRect.width - 12f, 1f));
+            Widgets.DrawBox(new Rect(inRect.x + 6f, inRect.y + 6f, 1f, inRect.height - 12f));
+            Widgets.DrawBox(new Rect(inRect.xMax - 7f, inRect.y + 6f, 1f, inRect.height - 12f));
+
+            GUI.color = Color.white;
+        }
+
+        private void DrawLoadingState(Rect inRect)
+        {
+            float centerX = inRect.width / 2f;
+            float centerY = inRect.height / 2f;
+
+            Text.Font = GameFont.Medium;
+            GUI.color = INK_COLOR;
+            Text.Anchor = TextAnchor.MiddleCenter;
+
+            Widgets.Label(new Rect(0f, centerY - 20f, inRect.width, 40f), loadingMessage);
+
+            Text.Anchor = TextAnchor.UpperLeft;
+            Text.Font = GameFont.Small;
+            GUI.color = Color.white;
+        }
+
+        private void DrawNoChronicleState(Rect inRect)
+        {
+            float centerX = inRect.width / 2f;
+            float centerY = inRect.height / 2f;
+
+            Text.Font = GameFont.Medium;
+            GUI.color = INK_COLOR;
+            Text.Anchor = TextAnchor.MiddleCenter;
+
+            Widgets.Label(new Rect(0f, centerY - 40f, inRect.width, 30f), "📰 Colony Chronicle");
+
+            Text.Font = GameFont.Small;
+            Widgets.Label(new Rect(20f, centerY, inRect.width - 40f, 60f),
+                "The Chronicle is published at the end of each week.\nCheck back when a new week begins!");
+
+            Text.Anchor = TextAnchor.UpperLeft;
+            GUI.color = Color.white;
+        }
+
+        private void DrawChronicleContent(Rect inRect)
+        {
+            // Content area with padding
+            float contentX = inRect.x + 20f;
+            float contentY = inRect.y + 20f;
+            float contentWidth = inRect.width - 40f;
+            float contentHeight = inRect.height - 40f;
+
+            // Calculate total height needed
+            totalHeight = CalculateChronicleHeight(chronicle, contentWidth);
+
+            // Begin scroll view
+            var viewRect = new Rect(contentX, contentY, contentWidth - 16f, Math.Max(totalHeight, contentHeight));
+
+            Widgets.BeginScrollView(new Rect(contentX, contentY, contentWidth, contentHeight),
+                ref scrollPosition, viewRect);
+
+            float y = 0f;
+
+            // Draw masthead (newspaper title)
+            y = DrawMasthead(chronicle, contentWidth, y);
+
+            // Draw date line
+            y = DrawDateLine(chronicle, contentWidth, y);
+
+            // Draw separator
+            y = DrawSeparator(contentWidth, y);
+
+            // Draw headline
+            y = DrawHeadline(chronicle, contentWidth, y);
+
+            // Draw lead paragraph
+            y = DrawLeadParagraph(chronicle, contentWidth, y);
+
+            // Draw sections
+            foreach (var section in chronicle.sections)
+            {
+                y = DrawSection(section, contentWidth, y);
+            }
+
+            // Draw quotes if any
+            if (chronicle.quotes != null && chronicle.quotes.Count > 0)
+            {
+                y = DrawQuotes(chronicle.quotes, contentWidth, y);
+            }
+
+            // Draw footer
+            y = DrawFooter(contentWidth, y);
+
+            Widgets.EndScrollView();
+        }
+
+        private float CalculateChronicleHeight(WeeklyChronicle chronicle, float width)
+        {
+            float y = 0f;
+
+            // Masthead
+            y += 45f;
+
+            // Date line
+            y += 18f;
+
+            // Separator
+            y += 12f;
+
+            // Headline
+            if (!string.IsNullOrEmpty(chronicle.topHeadline))
+                y += Text.CalcHeight(chronicle.topHeadline, width) + 8f;
+
+            // Lead paragraph
+            if (!string.IsNullOrEmpty(chronicle.leadParagraph))
+                y += Text.CalcHeight(chronicle.leadParagraph, width) + 16f;
+
+            // Sections
+            foreach (var section in chronicle.sections)
+            {
+                y += SECTION_MARGIN;
+                y += 20f; // Section title
+                if (!string.IsNullOrEmpty(section.content))
+                    y += Text.CalcHeight(section.content, width) + 4f;
+            }
+
+            // Quotes
+            if (chronicle.quotes != null && chronicle.quotes.Count > 0)
+            {
+                y += SECTION_MARGIN;
+                y += 20f;
+                foreach (var quote in chronicle.quotes)
+                {
+                    y += Text.CalcHeight($"\"{quote.quote}\" — {quote.colonistName}", width) + 4f;
+                }
+            }
+
+            // Footer
+            y += SECTION_MARGIN + 20f;
+
+            return y;
+        }
+
+        private float DrawMasthead(WeeklyChronicle chronicle, float width, float y)
+        {
+            Text.Font = GameFont.Medium;
+            GUI.color = HEADLINE_COLOR;
+            Text.Anchor = TextAnchor.UpperCenter;
+
+            string masthead = "📰 THE COLONY CHRONICLE 📰";
+            Widgets.Label(new Rect(0f, y, width, 30f), masthead);
+
+            Text.Font = GameFont.Tiny;
+            GUI.color = new Color(0.3f, 0.25f, 0.15f, 0.8f);
+
+            string tagline = "Your Trusted Source for Colony News Since Year One";
+            Widgets.Label(new Rect(0f, y + 22f, width, 16f), tagline);
+
+            y += 45f;
+
+            Text.Anchor = TextAnchor.UpperLeft;
+            GUI.color = Color.white;
+
+            return y;
+        }
+
+        private float DrawDateLine(WeeklyChronicle chronicle, float width, float y)
+        {
+            Text.Font = GameFont.Tiny;
+            GUI.color = new Color(0.35f, 0.3f, 0.2f, 0.9f);
+            Text.Anchor = TextAnchor.UpperCenter;
+
+            string dateLine = $"Week {chronicle.weekNumber} • {chronicle.season}, Day {chronicle.gameDay} • Year {chronicle.year}";
+            Widgets.Label(new Rect(0f, y, width, 16f), dateLine);
+
+            y += 18f;
+
+            Text.Anchor = TextAnchor.UpperLeft;
+            GUI.color = Color.white;
+
+            return y;
+        }
+
+        private float DrawSeparator(float width, float y)
+        {
+            GUI.color = SEPARATOR_COLOR;
+            Widgets.DrawLineHorizontal(0f, y + 3f, width);
+            GUI.color = new Color(0.5f, 0.4f, 0.3f, 0.4f);
+            Widgets.DrawLineHorizontal(0f, y + 5f, width);
+
+            y += 12f;
+            GUI.color = Color.white;
+
+            return y;
+        }
+
+        private float DrawHeadline(WeeklyChronicle chronicle, float width, float y)
+        {
+            if (string.IsNullOrEmpty(chronicle.topHeadline))
+                return y;
+
+            Text.Font = GameFont.Medium;
+            GUI.color = HEADLINE_COLOR;
+            Text.Anchor = TextAnchor.UpperCenter;
+
+            float height = Text.CalcHeight(chronicle.topHeadline, width);
+            Widgets.Label(new Rect(0f, y, width, height), chronicle.topHeadline);
+
+            y += height + 8f;
+
+            Text.Anchor = TextAnchor.UpperLeft;
+            Text.Font = GameFont.Small;
+            GUI.color = Color.white;
+
+            return y;
+        }
+
+        private float DrawLeadParagraph(WeeklyChronicle chronicle, float width, float y)
+        {
+            if (string.IsNullOrEmpty(chronicle.leadParagraph))
+                return y;
+
+            Text.Font = GameFont.Small;
+            GUI.color = INK_COLOR;
+            Text.Anchor = TextAnchor.UpperLeft;
+
+            float height = Text.CalcHeight(chronicle.leadParagraph, width);
+            Widgets.Label(new Rect(0f, y, width, height), chronicle.leadParagraph);
+
+            y += height + 16f;
+
+            Text.Anchor = TextAnchor.UpperLeft;
+            GUI.color = Color.white;
+
+            return y;
+        }
+
+        private float DrawSection(ChronicleSection section, float width, float y)
+        {
+            y += SECTION_MARGIN;
+
+            // Section header with emoji
+            Text.Font = GameFont.Small;
+            GUI.color = HEADLINE_COLOR;
+            Text.Anchor = TextAnchor.UpperLeft;
+
+            string header = $"  {section.emoji} {section.title} {section.emoji}  ";
+            Widgets.Label(new Rect(0f, y, width, 20f), header);
+
+            // Underline for section header
+            float headerWidth = Text.CalcSize(header).x;
+            GUI.color = SEPARATOR_COLOR;
+            Widgets.DrawLineHorizontal(0f, y + 18f, Math.Min(headerWidth, width));
+
+            y += 22f;
+
+            // Section content
+            if (!string.IsNullOrEmpty(section.content))
+            {
+                Text.Font = GameFont.Small;
+                GUI.color = INK_COLOR;
+
+                float contentHeight = Text.CalcHeight(section.content, width);
+                Widgets.Label(new Rect(0f, y, width, contentHeight), section.content);
+
+                y += contentHeight + 4f;
+            }
+
+            GUI.color = Color.white;
+
+            return y;
+        }
+
+        private float DrawQuotes(List<ColonistQuote> quotes, float width, float y)
+        {
+            y += SECTION_MARGIN;
+
+            // Section header
+            Text.Font = GameFont.Small;
+            GUI.color = HEADLINE_COLOR;
+            Text.Anchor = TextAnchor.UpperCenter;
+
+            string header = "  📜 NOTABLE QUOTES  ";
+            Widgets.Label(new Rect(0f, y, width, 20f), header);
+
+            float headerWidth = Text.CalcSize(header).x;
+            GUI.color = SEPARATOR_COLOR;
+            Widgets.DrawLineHorizontal(0f, y + 18f, Math.Min(headerWidth, width));
+
+            y += 24f;
+
+            // Individual quotes
+            Text.Font = GameFont.Small;
+            GUI.color = new Color(0.2f, 0.15f, 0.1f, 1f);
+            Text.Anchor = TextAnchor.UpperLeft;
+
+            foreach (var quote in quotes)
+            {
+                string quoteText = $"\"{quote.quote}\" — {quote.colonistName}";
+                float quoteHeight = Text.CalcHeight(quoteText, width);
+
+                Widgets.Label(new Rect(10f, y, width - 20f, quoteHeight), quoteText);
+                y += quoteHeight + 4f;
+            }
+
+            GUI.color = Color.white;
+
+            return y;
+        }
+
+        private float DrawFooter(float width, float y)
+        {
+            y += SECTION_MARGIN;
+
+            // Double line separator
+            GUI.color = SEPARATOR_COLOR;
+            Widgets.DrawLineHorizontal(0f, y, width);
+            GUI.color = new Color(0.5f, 0.4f, 0.3f, 0.4f);
+            Widgets.DrawLineHorizontal(0f, y + 2f, width);
+
+            y += 8f;
+
+            Text.Font = GameFont.Tiny;
+            GUI.color = new Color(0.4f, 0.35f, 0.25f, 0.8f);
+            Text.Anchor = TextAnchor.UpperCenter;
+
+            string footer = "— End of Chronicle —\nBrought to you by RimMind AI • The Colony's Trusted Advisor";
+            float footerHeight = Text.CalcHeight(footer, width);
+            Widgets.Label(new Rect(0f, y, width, footerHeight), footer);
+
+            Text.Anchor = TextAnchor.UpperLeft;
+            GUI.color = Color.white;
+
+            return y;
+        }
+    }
+}

--- a/Source/RimMind/Chronicle/ChronicleTracker.cs
+++ b/Source/RimMind/Chronicle/ChronicleTracker.cs
@@ -1,0 +1,671 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using RimWorld;
+using Verse;
+using RimMind.API;
+using RimMind.Core;
+using RimMind.Chat;
+
+namespace RimMind.Chronicle
+{
+    /// <summary>
+    /// GameComponent that tracks colony events throughout each week and generates
+    /// the weekly Colony Chronicle when a new week begins.
+    /// </summary>
+    public class ChronicleTracker : GameComponent
+    {
+        private const int TICKS_PER_DAY = 60000;
+        private const int DAYS_PER_WEEK = 7;
+
+        public static ChronicleTracker Instance => Current.Game?.GetComponent<ChronicleTracker>();
+
+        // Current week's event log (being accumulated)
+        private WeeklyEventLog currentWeekLog;
+
+        // The most recently generated Chronicle (ready to display)
+        private WeeklyChronicle currentChronicle;
+
+        // Previous week's Chronicle for viewing
+        private WeeklyChronicle previousChronicle;
+
+        // Tracking state
+        private int lastProcessedDay = 0;
+        private HashSet<int> trackedColonistIds = new HashSet<int>();
+
+        // LLM callback state
+        private bool isGeneratingChronicle = false;
+        private WeeklyEventLog pendingLogForGeneration;
+
+        // Wealth snapshots for tracking
+        private List<float> wealthSnapshots = new List<float>();
+        private List<int> colonistCountSnapshots = new List<int>();
+
+        // Track deaths detected via letters to avoid duplicates
+        private HashSet<string> processedDeathLetterIds = new HashSet<string>();
+
+        public ChronicleTracker(Game game)
+        {
+        }
+
+        public override void FinalizeInit()
+        {
+            base.FinalizeInit();
+
+            // Initialize on game start
+            var map = Find.CurrentMap;
+            if (map != null)
+            {
+                int currentDay = GenLocalDate.DayOfYear(map);
+                lastProcessedDay = currentDay;
+
+                int weekNumber = (currentDay - 1) / DAYS_PER_WEEK + 1;
+                int startDay = (weekNumber - 1) * DAYS_PER_WEEK + 1;
+                int endDay = weekNumber * DAYS_PER_WEEK;
+
+                currentWeekLog = new WeeklyEventLog(
+                    weekNumber,
+                    startDay,
+                    endDay,
+                    GenLocalDate.Season(map).LabelCap().ToString(),
+                    GenLocalDate.Year(map)
+                );
+
+                TrackInitialColonists(map);
+                TakeInitialSnapshot(map);
+            }
+        }
+
+        public override void GameComponentTick()
+        {
+            base.GameComponentTick();
+
+            var map = Find.CurrentMap;
+            if (map == null) return;
+
+            int currentDay = GenLocalDate.DayOfYear(map);
+
+            // Check for new day
+            if (currentDay != lastProcessedDay)
+            {
+                OnNewDay(map, currentDay);
+                lastProcessedDay = currentDay;
+            }
+
+            // Take periodic snapshots for the day
+            if (Find.TickManager.TicksGame % (TICKS_PER_DAY / 4) == 0) // Every 6 hours
+            {
+                TakePeriodicSnapshot(map);
+            }
+        }
+
+        private void OnNewDay(Map map, int newDay)
+        {
+            int weekNumber = (newDay - 1) / DAYS_PER_WEEK + 1;
+
+            // Check if we've crossed into a new week
+            if (currentWeekLog != null && weekNumber != currentWeekLog.weekNumber)
+            {
+                // Finalize the old week and generate Chronicle
+                FinalizeWeekAndGenerateChronicle(map, newDay, weekNumber);
+            }
+
+            // Initialize new week log if needed
+            if (currentWeekLog == null || currentWeekLog.weekNumber != weekNumber)
+            {
+                int startDay = (weekNumber - 1) * DAYS_PER_WEEK + 1;
+                int endDay = weekNumber * DAYS_PER_WEEK;
+
+                currentWeekLog = new WeeklyEventLog(
+                    weekNumber,
+                    startDay,
+                    endDay,
+                    GenLocalDate.Season(map).LabelCap().ToString(),
+                    GenLocalDate.Year(map)
+                );
+
+                // Check for new colonists
+                CheckForNewColonists(map);
+            }
+
+            // Daily event tracking
+            TrackDailyEvents(map, newDay);
+        }
+
+        private void TrackInitialColonists(Map map)
+        {
+            trackedColonistIds.Clear();
+            foreach (var colonist in map.mapPawns.FreeColonists)
+            {
+                trackedColonistIds.Add(colonist.thingIDNumber);
+            }
+        }
+
+        private void CheckForNewColonists(Map map)
+        {
+            foreach (var colonist in map.mapPawns.FreeColonists)
+            {
+                if (!trackedColonistIds.Contains(colonist.thingIDNumber))
+                {
+                    trackedColonistIds.Add(colonist.thingIDNumber);
+
+                    currentWeekLog?.milestones.Add($"{colonist.Name.ToStringShort} joined the colony!");
+                    currentWeekLog?.events.Add(new ColonyEvent(
+                        "recruitment",
+                        $"{colonist.Name.ToStringShort} has joined the colony!",
+                        colonist.Name.ToStringShort,
+                        GenLocalDate.DayOfYear(map)
+                    ));
+                }
+            }
+
+            // Check for departed colonists (raided, escaped, etc.)
+            var currentIds = new HashSet<int>(map.mapPawns.FreeColonists.Select(c => c.thingIDNumber));
+            var departedIds = trackedColonistIds.Except(currentIds).ToList();
+
+            foreach (var id in departedIds)
+            {
+                // We don't have the name anymore, but we can note a departure
+                currentWeekLog?.milestones.Add($"A colonist has left the colony.");
+            }
+
+            trackedColonistIds = currentIds;
+        }
+
+        private void TakeInitialSnapshot(Map map)
+        {
+            if (map == null) return;
+
+            float wealth = map.wealthWatcher.WealthTotal;
+            int colonistCount = map.mapPawns.FreeColonists.Count;
+
+            wealthSnapshots.Clear();
+            colonistCountSnapshots.Clear();
+
+            wealthSnapshots.Add(wealth);
+            colonistCountSnapshots.Add(colonistCount);
+
+            if (currentWeekLog != null)
+            {
+                currentWeekLog.highestWealth = wealth;
+                currentWeekLog.lowestWealth = wealth;
+                currentWeekLog.highestColonistCount = colonistCount;
+                currentWeekLog.lowestColonistCount = colonistCount;
+            }
+        }
+
+        private void TakePeriodicSnapshot(Map map)
+        {
+            if (map == null || currentWeekLog == null) return;
+
+            float wealth = map.wealthWatcher.WealthTotal;
+            int colonistCount = map.mapPawns.FreeColonists.Count;
+
+            wealthSnapshots.Add(wealth);
+            colonistCountSnapshots.Add(colonistCount);
+
+            if (wealth > currentWeekLog.highestWealth)
+                currentWeekLog.highestWealth = wealth;
+            if (wealth < currentWeekLog.lowestWealth && wealth > 0)
+                currentWeekLog.lowestWealth = wealth;
+
+            if (colonistCount > currentWeekLog.highestColonistCount)
+                currentWeekLog.highestColonistCount = colonistCount;
+            if (colonistCount < currentWeekLog.lowestColonistCount)
+                currentWeekLog.lowestColonistCount = colonistCount;
+
+            // Track mood extremes
+            foreach (var colonist in map.mapPawns.FreeColonists)
+            {
+                if (colonist.needs?.mood == null) continue;
+
+                float mood = colonist.needs.mood.CurLevel;
+                float deviation = Math.Abs(mood - 0.5f); // Deviation from neutral
+
+                if (deviation > Math.Abs(currentWeekLog.mostExtremeMoodValue - 0.5f))
+                {
+                    currentWeekLog.mostExtremeMoodColonist = colonist.Name.ToStringShort;
+                    currentWeekLog.mostExtremeMoodValue = mood;
+                }
+            }
+        }
+
+        private void TrackDailyEvents(Map map, int day)
+        {
+            if (currentWeekLog == null) return;
+
+            // Weather tracking
+            var weather = map.weatherManager.curWeather;
+            if (weather != null)
+            {
+                string weatherLabel = weather.LabelCap.ToString();
+                if (!weatherLabel.Contains("Clear") && !weatherLabel.Contains("Cloudy"))
+                {
+                    string weatherEntry = $"Day {day}: {weatherLabel}";
+                    if (!currentWeekLog.weatherEvents.Contains(weatherEntry))
+                    {
+                        currentWeekLog.weatherEvents.Add(weatherEntry);
+                    }
+                }
+            }
+        }
+
+        private void FinalizeWeekAndGenerateChronicle(Map map, int newDay, int newWeekNumber)
+        {
+            if (currentWeekLog == null) return;
+
+            // Move current to previous
+            previousChronicle = currentChronicle;
+
+            // Finalize current week stats
+            if (wealthSnapshots.Count > 0)
+            {
+                currentWeekLog.highestWealth = wealthSnapshots.Max();
+                currentWeekLog.lowestWealth = wealthSnapshots.Where(w => w > 0).DefaultIfEmpty(0).Min();
+            }
+
+            if (colonistCountSnapshots.Count > 0)
+            {
+                currentWeekLog.highestColonistCount = colonistCountSnapshots.Max();
+                currentWeekLog.lowestColonistCount = colonistCountSnapshots.Min();
+            }
+
+            // Create a log copy for generation (since currentWeekLog will be reset)
+            var logForGeneration = currentWeekLog;
+
+            // Send notification
+            SendChronicleNotification(logForGeneration);
+
+            // Generate the Chronicle via LLM
+            GenerateChronicleAsync(logForGeneration);
+        }
+
+        private void SendChronicleNotification(WeeklyEventLog log)
+        {
+            Find.LetterStack.ReceiveLetter(
+                "Colony Chronicle",
+                $"Week {log.weekNumber} has ended. The Colony Chronicle is being prepared...",
+                LetterDefOf.NeutralEvent
+            );
+        }
+
+        private void GenerateChronicleAsync(WeeklyEventLog log)
+        {
+            if (isGeneratingChronicle) return;
+            isGeneratingChronicle = true;
+            pendingLogForGeneration = log;
+
+            // Build the prompt for chronicle generation
+            string prompt = BuildChroniclePrompt(log);
+
+            // Create a simple chat request for chronicle generation
+            var messages = new List<ChatMessage>
+            {
+                ChatMessage.System(@"You are the editor of the Colony Chronicle, a newspaper for a RimWorld colony. 
+Generate a newspaper-style weekly chronicle based on the provided data.
+Write in an old-timey, witty newspaper style - think 1800s frontier newspaper meets dark humor.
+Be entertaining and dramatic, but mostly accurate to the data provided.
+Use section headers with emojis like newspapers do.
+
+FORMAT YOUR RESPONSE EXACTLY LIKE THIS (use this structure, fill in the content):
+
+[TITLE]
+The Colony Chronicle - Week {weekNumber}
+{season}, Day {startDay}-{endDay}
+
+[HEADLINE]
+{Your exciting headline here}
+
+[LEAD]
+{2-3 sentence lead paragraph summarizing the week}
+
+[SECTION:name:BATTLE REPORT:⚔️]
+{Section content here - describe battles, raids, fights}
+
+[SECTION:name:OBITUARIES:😢]
+{Section content here - list the dead, be appropriately somber}
+
+[SECTION:name:ECONOMY:📦]
+{Section content here - trades, wealth changes, resources}
+
+[SECTION:name:MILESTONES:🏆]
+{Section content here - achievements, births, notable events}
+
+[SECTION:name:WEATHER:🌤️]
+{Section content here - a brief, possibly poetic description of the weather}
+
+[SECTION:name:LOOKING AHEAD:🔮]
+{Section content here - a prediction or ominous warning about next week}
+
+[QUOTES]
+""Quote 1"" - ColonistName
+""Quote 2"" - ColonistName
+
+Use creative, entertaining language. This is a fictional newspaper for a harsh frontier colony."),
+                ChatMessage.User(prompt)
+            };
+
+            var request = new ChatRequest
+            {
+                model = RimMindMod.Settings.ActiveModelId,
+                messages = messages,
+                temperature = 0.9f,
+                max_tokens = 2000
+            };
+
+            Action<ChatResponse> handleResponse = response =>
+            {
+                isGeneratingChronicle = false;
+
+                if (!response.success)
+                {
+                    Log.Warning("[RimMind] Chronicle generation failed: " + response.error);
+                    // Create a fallback chronicle
+                    currentChronicle = CreateFallbackChronicle(log);
+                    return;
+                }
+
+                string content = response.message?.content ?? "";
+                currentChronicle = ParseChronicleResponse(content, log);
+            };
+
+            // Send to the appropriate API
+            if (RimMindMod.Settings.IsClaudeCode)
+                ClaudeCodeClient.SendAsync(request, handleResponse);
+            else if (RimMindMod.Settings.IsAnthropic)
+                AnthropicClient.SendAsync(request, handleResponse);
+            else if (RimMindMod.Settings.IsCustom)
+                CustomProviderClient.SendAsync(request, handleResponse);
+            else
+                OpenRouterClient.SendAsync(request, handleResponse);
+        }
+
+        private string BuildChroniclePrompt(WeeklyEventLog log)
+        {
+            return log.BuildContextSummary();
+        }
+
+        private WeeklyChronicle ParseChronicleResponse(string content, WeeklyEventLog log)
+        {
+            var chronicle = new WeeklyChronicle(
+                log.weekNumber,
+                log.endDay,
+                log.season,
+                log.year
+            );
+
+            chronicle.events = new List<ColonyEvent>(log.events);
+            chronicle.quotes = new List<ColonistQuote>(log.quotes);
+            chronicle.milestones = new List<string>(log.milestones);
+            chronicle.weatherPoem = "Weather was uneventful this week.";
+
+            // Parse the content into sections
+            // The LLM should format it with [SECTION:name:emoji] markers
+            // But we'll parse what we can from plain text
+
+            if (string.IsNullOrEmpty(content))
+            {
+                return CreateFallbackChronicle(log);
+            }
+
+            // Simple parsing - look for section markers
+            var lines = content.Split('\n');
+            ChronicleSection currentSection = null;
+
+            foreach (var line in lines)
+            {
+                string trimmed = line.Trim();
+
+                if (trimmed.StartsWith("[HEADLINE]"))
+                {
+                    chronicle.topHeadline = trimmed.Substring("[HEADLINE]".Length).Trim();
+                }
+                else if (trimmed.StartsWith("[LEAD]"))
+                {
+                    chronicle.leadParagraph = trimmed.Substring("[LEAD]".Length).Trim();
+                }
+                else if (trimmed.StartsWith("[QUOTES]"))
+                {
+                    currentSection = null; // Quotes handled separately
+                }
+                else if (trimmed.StartsWith("[SECTION:"))
+                {
+                    // Parse [SECTION:name:emoji]
+                    int firstColon = trimmed.IndexOf(':');
+                    int secondColon = trimmed.IndexOf(':', firstColon + 1);
+                    int closingBracket = trimmed.IndexOf(']', secondColon + 1);
+
+                    if (firstColon > 0 && secondColon > firstColon && closingBracket > secondColon)
+                    {
+                        string name = trimmed.Substring(firstColon + 1, secondColon - firstColon - 1);
+                        string emoji = trimmed.Substring(secondColon + 1, closingBracket - secondColon - 1);
+
+                        currentSection = new ChronicleSection(name, emoji, "");
+                        chronicle.sections.Add(currentSection);
+                    }
+                }
+                else if (currentSection != null)
+                {
+                    if (string.IsNullOrEmpty(currentSection.content))
+                        currentSection.content = trimmed;
+                    else
+                        currentSection.content += "\n" + trimmed;
+                }
+                else if (trimmed.StartsWith("\"") && trimmed.EndsWith("\""))
+                {
+                    // Likely a quote
+                    var quoteText = trimmed.Trim('"');
+                    var parts = quoteText.Split(new[] { " - ", " — " }, StringSplitOptions.None);
+                    if (parts.Length >= 2)
+                    {
+                        chronicle.quotes.Add(new ColonistQuote(parts[1], parts[0]));
+                    }
+                }
+            }
+
+            // If we couldn't parse sections, create some default ones
+            if (chronicle.sections.Count == 0)
+            {
+                chronicle.sections.Add(new ChronicleSection("BATTLE REPORT", "⚔️",
+                    log.raids > 0 ? $"{log.raids} raid(s) occurred this week." : "A quiet week on the battlefield."));
+
+                chronicle.sections.Add(new ChronicleSection("OBITUARIES", "😢",
+                    log.deaths > 0 ? $"{log.deaths} colonist(s) passed away." : "No deaths this week. A blessing."));
+
+                chronicle.sections.Add(new ChronicleSection("ECONOMY", "📦",
+                    $"Colony wealth: {log.highestWealth:N0} silver. {log.trades} trade(s) conducted."));
+
+                chronicle.sections.Add(new ChronicleSection("MILESTONES", "🏆",
+                    log.milestones.Count > 0 ? string.Join("\n", log.milestones) : "No major milestones."));
+
+                if (log.weatherEvents.Count > 0)
+                {
+                    chronicle.sections.Add(new ChronicleSection("WEATHER", "🌤️",
+                        string.Join("\n", log.weatherEvents)));
+                }
+            }
+
+            chronicle.isGenerated = true;
+            return chronicle;
+        }
+
+        private WeeklyChronicle CreateFallbackChronicle(WeeklyEventLog log)
+        {
+            var chronicle = new WeeklyChronicle(
+                log.weekNumber,
+                log.endDay,
+                log.season,
+                log.year
+            );
+
+            chronicle.topHeadline = $"Week {log.weekNumber}: The Colony Endures";
+            chronicle.leadParagraph = $"As Day {log.endDay} closes, the colonists of this settlement reflect on a week of challenges and small victories. The {log.season} season brings its own trials.";
+
+            chronicle.sections.Add(new ChronicleSection("BATTLE REPORT", "⚔️",
+                log.raids > 0 ? $"{log.raids} raid(s) tested our defenses." : "The enemy held back this week. Enjoy the peace while it lasts."));
+
+            chronicle.sections.Add(new ChronicleSection("OBITUARIES", "😢",
+                log.deaths > 0 ? $"{log.deaths} soul(s) departed this mortal colony." : "No deaths recorded. The Reaper takes a holiday."));
+
+            chronicle.sections.Add(new ChronicleSection("ECONOMY", "📦",
+                $"Wealth peaked at {log.highestWealth:N0} silver. {log.trades} caravan(s) visited our trade depots."));
+
+            chronicle.sections.Add(new ChronicleSection("MILESTONES", "🏆",
+                log.milestones.Count > 0 ? string.Join("\n", log.milestones) : "The colony grows, one day at a time."));
+
+            if (log.weatherEvents.Count > 0)
+            {
+                chronicle.sections.Add(new ChronicleSection("WEATHER", "🌤️",
+                    string.Join("\n", log.weatherEvents)));
+            }
+
+            chronicle.events = new List<ColonyEvent>(log.events);
+            chronicle.quotes = new List<ColonistQuote>(log.quotes);
+            chronicle.milestones = new List<string>(log.milestones);
+            chronicle.isGenerated = true;
+
+            return chronicle;
+        }
+
+        // ========================
+        // PUBLIC API
+        // ========================
+
+        /// <summary>
+        /// Records a significant event for the current week.
+        /// </summary>
+        public void RecordEvent(ColonyEvent evt)
+        {
+            currentWeekLog?.events.Add(evt);
+
+            switch (evt.type)
+            {
+                case "death":
+                    currentWeekLog.deaths++;
+                    break;
+                case "raid":
+                case "attack":
+                    currentWeekLog.raids++;
+                    break;
+                case "trade":
+                    currentWeekLog.trades++;
+                    break;
+                case "birth":
+                    currentWeekLog.births++;
+                    break;
+                case "mental_break":
+                    currentWeekLog.mentalBreaks++;
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Records a colonist's quote for the current week.
+        /// </summary>
+        public void RecordQuote(ColonistQuote quote)
+        {
+            currentWeekLog?.quotes.Add(quote);
+        }
+
+        /// <summary>
+        /// Records a milestone achievement for the current week.
+        /// </summary>
+        public void RecordMilestone(string milestone)
+        {
+            currentWeekLog?.milestones.Add(milestone);
+        }
+
+        /// <summary>
+        /// Records a research completion.
+        /// </summary>
+        public void RecordResearchCompletion(string researchName)
+        {
+            if (currentWeekLog != null)
+            {
+                currentWeekLog.researchCompleted++;
+                currentWeekLog.milestones.Add($"Completed research: {researchName}");
+            }
+        }
+
+        /// <summary>
+        /// Records a successful surgery.
+        /// </summary>
+        public void RecordSurgery()
+        {
+            if (currentWeekLog != null)
+            {
+                currentWeekLog.surgeries++;
+            }
+        }
+
+        /// <summary>
+        /// Records an animal taming.
+        /// </summary>
+        public void RecordAnimalTamed(string animalName)
+        {
+            if (currentWeekLog != null)
+            {
+                currentWeekLog.animalsTamed++;
+                currentWeekLog.milestones.Add($"Tamed a {animalName}");
+            }
+        }
+
+        /// <summary>
+        /// Gets the most recently generated chronicle, or null if none exists.
+        /// </summary>
+        public WeeklyChronicle GetCurrentChronicle()
+        {
+            return currentChronicle;
+        }
+
+        /// <summary>
+        /// Gets the previous week's chronicle.
+        /// </summary>
+        public WeeklyChronicle GetPreviousChronicle()
+        {
+            return previousChronicle;
+        }
+
+        /// <summary>
+        /// Checks if a chronicle is currently being generated.
+        /// </summary>
+        public bool IsGeneratingChronicle => isGeneratingChronicle;
+
+        /// <summary>
+        /// Gets the current week's event log.
+        /// </summary>
+        public WeeklyEventLog GetCurrentWeekLog()
+        {
+            return currentWeekLog;
+        }
+
+        public override void ExposeData()
+        {
+            base.ExposeData();
+
+            // Note: WeeklyChronicle and WeeklyEventLog contain complex nested types
+            // that aren't directly Scribe-compatible. We skip saving them for now
+            // and let them rebuild at week end, or implement custom serialization later.
+            // For a Phase 1, we'll just preserve tracking state.
+
+            Scribe_Values.Look(ref lastProcessedDay, "lastProcessedDay");
+
+            // Handle tracked colonist IDs
+            if (Scribe.mode == LoadSaveMode.Saving)
+            {
+                var idsList = trackedColonistIds.ToList();
+                Scribe_Collections.Look(ref idsList, "trackedColonistIds", LookMode.Value);
+            }
+            else if (Scribe.mode == LoadSaveMode.LoadingVars)
+            {
+                var idsList = new List<int>();
+                Scribe_Collections.Look(ref idsList, "trackedColonistIds", LookMode.Value);
+                if (idsList != null)
+                    trackedColonistIds = new HashSet<int>(idsList);
+            }
+
+            Scribe_Collections.Look(ref wealthSnapshots, "wealthSnapshots", LookMode.Value);
+            Scribe_Collections.Look(ref colonistCountSnapshots, "colonistCountSnapshots", LookMode.Value);
+        }
+    }
+}


### PR DESCRIPTION
Adds the Colony Chronicle feature - a newspaper-style weekly report for RimWorld colonies.

## Files Created
- ChronicleData.cs - Data classes (WeeklyChronicle, ChronicleSection, ColonyEvent, ColonistQuote, WeeklyEventLog)
- ChronicleTracker.cs - GameComponent that tracks events weekly and generates Chronicle via LLM
- ChronicleTab.cs - Newspaper-style UI window with parchment background

## Files Modified
- ChatWindow.cs - Added Chronicle button

## How to Test
1. Open RimMind (bottom-right button)
2. Click the Chronicle button
3. View the newspaper-style weekly report

## Limitations (Phase 2)
- Chronicle data not persisted across save/load
- Event detection could be more comprehensive
- No translation keys yet